### PR TITLE
Update virtualenv example

### DIFF
--- a/examples/pyspark/dependencies/Dockerfile
+++ b/examples/pyspark/dependencies/Dockerfile
@@ -1,11 +1,14 @@
-FROM python:3.7.9-buster AS base
+FROM amazonlinux:2 AS base
+
+RUN yum install -y python3
 
 ENV VIRTUAL_ENV=/opt/venv
 RUN python3 -m venv $VIRTUAL_ENV
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
-RUN pip install \
-    great_expectations==0.14.3 \
+RUN python3 -m pip install --upgrade pip && \
+    python3 -m pip install \
+    great_expectations==0.15.6 \
     venv-pack==0.2.0
 
 RUN mkdir /output && venv-pack -o /output/pyspark_ge.tar.gz

--- a/examples/pyspark/dependencies/ge_profile.py
+++ b/examples/pyspark/dependencies/ge_profile.py
@@ -1,34 +1,27 @@
 import sys
 from pyspark.sql import SparkSession
 
-def add_venv_to_path(archive_name):
-    print(f"Adding {archive_name} to sys.path")
-    userFilesDir = [match for match in sys.path if "userFiles" in match][0]
-    sys.path.append(f"{userFilesDir}/{archive_name}/lib/python3.7/site-packages")
+import great_expectations as ge
+from great_expectations.profile.basic_dataset_profiler import BasicDatasetProfiler
+from great_expectations.dataset.sparkdf_dataset import SparkDFDataset
+from great_expectations.render.renderer import *
+from great_expectations.render.view import DefaultJinjaPageView
+
 
 if __name__ == "__main__":
     """
-        Usage: ge-profile <venv_archive.tar.gz> <s3_output_path.html>
+        Usage: ge-profile <s3_output_path.html>
     """
     spark = SparkSession\
         .builder\
         .appName("GEProfiler")\
         .getOrCreate()
     
-    if len(sys.argv) != 3:
-        print("Invalid arguments, please supply <venv_archive.tar.gz> <s3_output_path.html>")
+    if len(sys.argv) != 2:
+        print("Invalid arguments, please supply <s3_output_path.html>")
         sys.exit(1)
 
-    archive_name = sys.argv[1]
-    output_path = sys.argv[2]
-    add_venv_to_path(archive_name)
-
-    # Imports need to be made after adding the virtualenv to the path
-    import great_expectations as ge
-    from great_expectations.profile.basic_dataset_profiler import BasicDatasetProfiler
-    from great_expectations.dataset.sparkdf_dataset import SparkDFDataset
-    from great_expectations.render.renderer import *
-    from great_expectations.render.view import DefaultJinjaPageView
+    output_path = sys.argv[1]
 
     # Read some trip data
     df = spark.read.csv("s3://nyc-tlc/trip data/yellow*.csv", header=True)


### PR DESCRIPTION
- Uses `amazonlinux:2` as base
- Removes `add_venv_to_path` workaround