### PR TITLE
Add config options to hook 

### DIFF
--- a/airflow/emr_serverless/hooks/emr.py
+++ b/airflow/emr_serverless/hooks/emr.py
@@ -144,6 +144,7 @@ class EmrServerlessHook(AwsBaseHook):
         execution_role_arn: str,
         job_driver: dict,
         configuration_overrides: Optional[dict],
+        **kwargs,
     ) -> Dict:
         """
         Starts an EMR Serverless job on a created application.
@@ -171,6 +172,7 @@ class EmrServerlessHook(AwsBaseHook):
                 executionRoleArn=execution_role_arn,
                 jobDriver=job_driver,
                 configurationOverrides=configuration_overrides,
+                **kwargs,
             )
         except Exception as ex:
             self.log.error(f"Exception while starting job: {ex}")

--- a/airflow/emr_serverless/operators/emr.py
+++ b/airflow/emr_serverless/operators/emr.py
@@ -114,9 +114,10 @@ class EmrServerlessStartJobOperator(BaseOperator):
       Its value must be unique for each request.
     :param wait_for_completion: If true, waits for the job to start before returning. Defaults to True.
     :param aws_conn_id: AWS connection to use
+    :param config: extra configuration for the job.
     """
 
-    template_fields: Sequence[str] = ("application_id",)
+    template_fields: Sequence[str] = ("application_id", "execution_role_arn", "job_driver", "configuration_overrides")
 
     def __init__(
         self,


### PR DESCRIPTION
*Description of changes:*

Add more template field options to EmrServerlessStartJobOperator
Add **kwargs on emr serverless hook to be able to correctly pass config parameters from operator to hook


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
