### PR TITLE
fixed function typos that prevented seeing job errors

### DIFF
--- a/airflow/emr_serverless/hooks/emr.py
+++ b/airflow/emr_serverless/hooks/emr.py
@@ -201,7 +201,7 @@ class EmrServerlessHook(AwsBaseHook):
         reason = None
 
         try:
-            response = self.conn.describe_job_run(
+            response = self.conn.get_job_run(
                 applicationId=application_id,
                 jobRunId=job_run_id,
             )

--- a/airflow/emr_serverless/operators/emr.py
+++ b/airflow/emr_serverless/operators/emr.py
@@ -173,7 +173,7 @@ class EmrServerlessStartJobOperator(BaseOperator):
                 self.application_id, job_run_id
             )
             if query_status in EmrServerlessJobSensor.FAILURE_STATES:
-                error_message = emr_serverless_hook.get_serverless_job_state_details(self.job_id)
+                error_message = emr_serverless_hook.get_serverless_job_state_details(self.application_id, job_run_id)
                 raise AirflowException(
                     f"EMR Serverless job failed. Final state is {query_status}. "
                     f"job_run_id is {job_run_id}. Error: {error_message}"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
When a job would fail, instead of getting the EMR failure message code would dump:
AttributeError: 'EmrServerlessStartJobOperator' object has no attribute 'job_id'

After fixing that, we get the below:
AttributeError: 'EMRServerless' object has no attribute 'describe_job_run'

The two files were updated and now we can see the actual job error:
Example:  airflow.exceptions.AirflowException: EMR Serverless job failed. Final state is FAILED. job_run_id is xxxxxxxx. Error: Job execution failed, please check complete logs in configured logging destination. ExitCode: 1. Last few exceptions: IndentationError: unexpected indent...

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
