### PR TITLE
Fix/airflow exceptions

### DIFF
--- a/airflow/dags/example_emr_serverless.py
+++ b/airflow/dags/example_emr_serverless.py
@@ -15,7 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-import os
 from datetime import datetime
 
 from airflow import DAG

--- a/airflow/emr_serverless/operators/emr.py
+++ b/airflow/emr_serverless/operators/emr.py
@@ -217,7 +217,7 @@ class EmrServerlessStartJobOperator(BaseOperator):
                     "jobRunId": response["jobRunId"],
                 },
                 parse_response=["jobRun", "state"],
-                desired_state=EmrServerlessJobSensor.TERMINAL_STATES,
+                desired_state=EmrServerlessJobSensor.SUCCESS_STATES,
                 failure_states=EmrServerlessJobSensor.FAILURE_STATES,
                 object_type="job",
                 action="run",

--- a/airflow/emr_serverless/operators/emr.py
+++ b/airflow/emr_serverless/operators/emr.py
@@ -236,7 +236,7 @@ class EmrServerlessDeleteApplicationOperator(BaseOperator):
     :param aws_conn_id: AWS connection to use
     """
 
-    template_fields: Sequence[str] = "application_id"
+    template_fields: Sequence[str] = ("application_id",)
 
     def __init__(
         self,


### PR DESCRIPTION
Fixes #21 and #22 

- We were looking for the incorrect state such that if a job failed, it would still be marked as success in Airflow.
- There was an error when syncing the code from the Airflow PR

Tested this on MWAA with Airflow 2.2.2