### PR TITLE
Add EMR Serverless CloudWatch Dashboard to CDK Stack

### DIFF
--- a/cdk/emr-serverless-with-mwaa/README.md
+++ b/cdk/emr-serverless-with-mwaa/README.md
@@ -13,7 +13,7 @@ source .venv/bin/activate
 pip install -r requirements.txt
 ```
 
-One you've got CDK and Python setup, you can use `cdk deploy --all --output out.json` to deploy the stack and write outputs to a JSON file.
+One you've got CDK and Python setup, you can use `cdk deploy --all --outputs-file out.json` to deploy the stack and write outputs to a JSON file.
 
 The stack that's created uses [pre-initialized capacity](https://docs.aws.amazon.com/emr/latest/EMR-Serverless-UserGuide/application-capacity.html) so that Spark jobs can start instantly, but note that this can result in additional cost as resources are maintained for a certain period of time after jobs finish their runs.
 

--- a/cdk/emr-serverless-with-mwaa/requirements.txt
+++ b/cdk/emr-serverless-with-mwaa/requirements.txt
@@ -1,2 +1,2 @@
-aws-cdk-lib==2.27.0
+aws-cdk-lib==2.44.0
 constructs>=10.0.0,<11.0.0

--- a/cdk/emr-serverless-with-mwaa/stacks/emr_serverless.py
+++ b/cdk/emr-serverless-with-mwaa/stacks/emr_serverless.py
@@ -235,6 +235,7 @@ class EMRServerlessStack(Stack):
                 title=name,
                 period=Duration.minutes(1),
                 width=12,
+                stacked=True,
                 left=[
                     cw.MathExpression(
                         expression="m1+m2",
@@ -309,6 +310,7 @@ class EMRServerlessStack(Stack):
                 title="Running Workers",
                 period=Duration.minutes(1),
                 width=12,
+                stacked=True,
                 left=[
                     cw.MathExpression(
                         expression="m1+m2+m5",
@@ -350,6 +352,7 @@ class EMRServerlessStack(Stack):
                 title="Pre-Initialized Capacity: Total Workers",
                 period=Duration.minutes(1),
                 width=12,
+                stacked=True,
                 left=[
                     cw.MathExpression(
                         expression="m1+m2+m3",
@@ -367,6 +370,7 @@ class EMRServerlessStack(Stack):
                 title="Pre-Initialized Capacity: Worker Utilization %",
                 period=Duration.minutes(1),
                 width=12,
+                stacked=True,
                 left=[
                     cw.MathExpression(
                         expression="100*((m1+m2)/(m1+m2+m3))",
@@ -386,6 +390,7 @@ class EMRServerlessStack(Stack):
                 title="Pre-Initialized Capacity: Idle Workers",
                 period=Duration.minutes(1),
                 width=12,
+                stacked=True,
                 left=[idle_workers],
             )
         )
@@ -417,6 +422,7 @@ class EMRServerlessStack(Stack):
                         title=row[0]["name"],
                         period=Duration.minutes(1),
                         width=12,
+                        stacked=True,
                         left=[
                             cw.Metric(
                                 metric_name=row[0]["metric"],
@@ -448,6 +454,7 @@ class EMRServerlessStack(Stack):
                         title=row[1]["name"],
                         period=Duration.minutes(1),
                         width=12,
+                        stacked=True,
                         left=[
                             cw.Metric(
                                 metric_name=row[1]["metric"],

--- a/cdk/emr-serverless-with-mwaa/stacks/emr_serverless.py
+++ b/cdk/emr-serverless-with-mwaa/stacks/emr_serverless.py
@@ -1,7 +1,7 @@
-from aws_cdk import CfnOutput, Stack
+from aws_cdk import CfnOutput, Duration, Stack
+from aws_cdk import aws_cloudwatch as cw
 from aws_cdk import aws_ec2 as ec2
 from aws_cdk import aws_emrserverless as emrs
-from aws_cdk import aws_iam as iam
 from constructs import Construct
 
 
@@ -13,6 +13,7 @@ class EMRServerlessStack(Stack):
     ) -> None:
         super().__init__(scope, construct_id, **kwargs)
 
+        # Create an EMR 6.6.0 Spark application in a VPC with pre-initialized capacity
         self.serverless_app = emrs.CfnApplication(
             self,
             "spark_app",
@@ -48,7 +49,432 @@ class EMRServerlessStack(Stack):
             ),
         )
 
+        # Also create a CloudWatch Dashboard for the above application
+        dashboard = self.build_cloudwatch_dashboard(
+            self.serverless_app.attr_application_id
+        )
+
         CfnOutput(self, "ApplicationID", value=self.serverless_app.attr_application_id)
 
     def create_security_group(self, vpc: ec2.IVpc) -> ec2.SecurityGroup:
         return ec2.SecurityGroup(self, "EMRServerlessSG", vpc=vpc)
+
+    def build_cloudwatch_dashboard(self, application_id: str) -> cw.Dashboard:
+        dashboard = cw.Dashboard(
+            self,
+            "EMRServerlessDashboard",
+            dashboard_name=f"emr-serverless-dashboard-{self.serverless_app.attr_application_id}",
+        )
+
+        # First we have a set of metrics for running workers broken down by the following:
+        # - WorkerType (Driver or Executor)
+        # - CapacityAllocationType (PreInitCapacity or OnDemandCapacity)
+        preinit_driver_running_workers = cw.Metric(
+            metric_name="RunningWorkerCount",
+            namespace="AWS/EMRServerless",
+            dimensions_map={
+                "WorkerType": "Spark_Driver",
+                "CapacityAllocationType": "PreInitCapacity",
+                "ApplicationId": self.serverless_app.attr_application_id,
+            },
+            statistic="Sum",
+            label="Pre-Initialized",
+            period=Duration.minutes(1),
+        )
+        preinit_executor_running_workers = cw.Metric(
+            metric_name="RunningWorkerCount",
+            namespace="AWS/EMRServerless",
+            dimensions_map={
+                "WorkerType": "Spark_Executor",
+                "CapacityAllocationType": "PreInitCapacity",
+                "ApplicationId": self.serverless_app.attr_application_id,
+            },
+            statistic="Sum",
+            label="Pre-Initialized",
+            period=Duration.minutes(1),
+        )
+        ondemand_driver_running_workers = cw.Metric(
+            metric_name="RunningWorkerCount",
+            namespace="AWS/EMRServerless",
+            dimensions_map={
+                "WorkerType": "Spark_Driver",
+                "CapacityAllocationType": "OnDemandCapacity",
+                "ApplicationId": self.serverless_app.attr_application_id,
+            },
+            statistic="Sum",
+            label="OnDemand",
+            period=Duration.minutes(1),
+        )
+        ondemand_executor_running_workers = cw.Metric(
+            metric_name="RunningWorkerCount",
+            namespace="AWS/EMRServerless",
+            dimensions_map={
+                "WorkerType": "Spark_Executor",
+                "CapacityAllocationType": "OnDemandCapacity",
+                "ApplicationId": self.serverless_app.attr_application_id,
+            },
+            statistic="Sum",
+            label="OnDemand",
+            period=Duration.minutes(1),
+        )
+
+        idle_workers = cw.Metric(
+            metric_name="IdleWorkerCount",
+            namespace="AWS/EMRServerless",
+            dimensions_map={
+                "ApplicationId": self.serverless_app.attr_application_id,
+            },
+            statistic="Sum",
+            period=Duration.minutes(1),
+        )
+        dashboard.add_widgets(
+            cw.GaugeWidget(
+                title="Pre-Initialized Capacity Worker Utilization %",
+                period=Duration.minutes(1),
+                width=12,
+                metrics=[
+                    cw.MathExpression(
+                        expression="100*((m1+m2)/(m1+m2+m3))",
+                        label="Pre-Init Worker Utilization %",
+                        using_metrics={
+                            "m1": cw.Metric(
+                                metric_name="RunningWorkerCount",
+                                namespace="AWS/EMRServerless",
+                                dimensions_map={
+                                    "WorkerType": "Spark_Driver",
+                                    "CapacityAllocationType": "PreInitCapacity",
+                                    "ApplicationId": self.serverless_app.attr_application_id,
+                                },
+                            ),
+                            "m2": cw.Metric(
+                                metric_name="RunningWorkerCount",
+                                namespace="AWS/EMRServerless",
+                                dimensions_map={
+                                    "WorkerType": "Spark_Executor",
+                                    "CapacityAllocationType": "PreInitCapacity",
+                                    "ApplicationId": self.serverless_app.attr_application_id,
+                                },
+                            ),
+                            "m3": cw.Metric(
+                                metric_name="IdleWorkerCount",
+                                namespace="AWS/EMRServerless",
+                                dimensions_map={
+                                    "ApplicationId": self.serverless_app.attr_application_id,
+                                },
+                            ),
+                        },
+                    )
+                ],
+            ),
+            cw.SingleValueWidget(
+                title="Running Drivers",
+                width=12,
+                height=6,
+                metrics=[
+                    preinit_driver_running_workers,
+                    ondemand_driver_running_workers,
+                ],
+                sparkline=True,
+            ),
+        )
+
+        dashboard.add_widgets(
+            cw.SingleValueWidget(
+                title="Available Workers",
+                width=12,
+                height=6,
+                sparkline=True,
+                metrics=[
+                    cw.MathExpression(
+                        expression="m1+m2+m5",
+                        label="Pre-Initialized",
+                        period=Duration.minutes(1),
+                        using_metrics={
+                            "m1": preinit_driver_running_workers,
+                            "m2": preinit_executor_running_workers,
+                            "m5": idle_workers,
+                        },
+                    ),
+                    cw.MathExpression(
+                        expression="m3+m4",
+                        label="OnDemand",
+                        period=Duration.minutes(1),
+                        using_metrics={
+                            "m3": ondemand_driver_running_workers,
+                            "m4": ondemand_executor_running_workers,
+                        },
+                        color="#ff7f0e",
+                    ),
+                ],
+            ),
+            cw.SingleValueWidget(
+                title="Running Executors",
+                width=12,
+                height=6,
+                sparkline=True,
+                metrics=[
+                    preinit_executor_running_workers,
+                    ondemand_executor_running_workers,
+                ],
+            ),
+        )
+
+        ## BEGIN: APPLICATION METRICS SECTION
+        dashboard.add_widgets(
+            cw.TextWidget(
+                markdown=f"Application Metrics\n---\nApplication metrics shows the capacity used by application **({application_id})**.",
+                height=2,
+                width=24,
+            )
+        )
+
+        # Build up a list of metrics across different capacity metrics (cpu, memory, storage)
+        capacity_metric_names = ["CPUAllocated", "MemoryAllocated", "StorageAllocated"]
+        app_graph_widgets = [
+            cw.GraphWidget(
+                title=name,
+                period=Duration.minutes(1),
+                width=12,
+                left=[
+                    cw.MathExpression(
+                        expression="m1+m2",
+                        label="Pre-Initialized",
+                        period=Duration.minutes(1),
+                        using_metrics={
+                            "m1": cw.Metric(
+                                metric_name=name,
+                                namespace="AWS/EMRServerless",
+                                dimensions_map={
+                                    "WorkerType": "Spark_Driver",
+                                    "CapacityAllocationType": "PreInitCapacity",
+                                    "ApplicationId": self.serverless_app.attr_application_id,
+                                },
+                                statistic="Sum",
+                                label="Pre-Initialized Spark Driver",
+                                period=Duration.minutes(1),
+                            ),
+                            "m2": cw.Metric(
+                                metric_name=name,
+                                namespace="AWS/EMRServerless",
+                                dimensions_map={
+                                    "WorkerType": "Spark_Executor",
+                                    "CapacityAllocationType": "PreInitCapacity",
+                                    "ApplicationId": self.serverless_app.attr_application_id,
+                                },
+                                statistic="Sum",
+                                label="Pre-Initialized Spark Executor",
+                                period=Duration.minutes(1),
+                            ),
+                        },
+                    ),
+                    cw.MathExpression(
+                        expression="m3+m4",
+                        label="OnDemand",
+                        period=Duration.minutes(1),
+                        color="#ff7f0e",
+                        using_metrics={
+                            "m3": cw.Metric(
+                                metric_name=name,
+                                namespace="AWS/EMRServerless",
+                                dimensions_map={
+                                    "WorkerType": "Spark_Driver",
+                                    "CapacityAllocationType": "OnDemandCapacity",
+                                    "ApplicationId": self.serverless_app.attr_application_id,
+                                },
+                                statistic="Sum",
+                                label="OnDemand Spark Driver",
+                                period=Duration.minutes(1),
+                            ),
+                            "m4": cw.Metric(
+                                metric_name=name,
+                                namespace="AWS/EMRServerless",
+                                dimensions_map={
+                                    "WorkerType": "Spark_Executor",
+                                    "CapacityAllocationType": "OnDemandCapacity",
+                                    "ApplicationId": self.serverless_app.attr_application_id,
+                                },
+                                statistic="Sum",
+                                label="OnDemand Spark Executor",
+                                period=Duration.minutes(1),
+                            ),
+                        },
+                    ),
+                ],
+            )
+            for name in capacity_metric_names
+        ]
+
+        dashboard.add_widgets(
+            cw.GraphWidget(
+                title="Running Workers",
+                period=Duration.minutes(1),
+                width=12,
+                left=[
+                    cw.MathExpression(
+                        expression="m1+m2+m5",
+                        label="Pre-Initialized",
+                        period=Duration.minutes(1),
+                        using_metrics={
+                            "m1": preinit_driver_running_workers,
+                            "m2": preinit_executor_running_workers,
+                            "m5": idle_workers,
+                        },
+                    ),
+                    cw.MathExpression(
+                        expression="m3+m4",
+                        label="OnDemand",
+                        period=Duration.minutes(1),
+                        using_metrics={
+                            "m3": ondemand_driver_running_workers,
+                            "m4": ondemand_executor_running_workers,
+                        },
+                        color="#ff7f0e",
+                    ),
+                ],
+            ),
+            app_graph_widgets[0],
+        )
+        dashboard.add_widgets(*app_graph_widgets[1:])
+        ## END: APPLICATION METRICS SECTION
+
+        ## BEGIN: PRE-INITIALIZED CAPACITY METRICS
+        dashboard.add_widgets(
+            cw.TextWidget(
+                markdown=f"Pre-Initialized Capacity Metrics\n---\nShows you the Pre-Initialized Capacity metrics for an Application.",
+                height=2,
+                width=24,
+            )
+        )
+        dashboard.add_widgets(
+            cw.GraphWidget(
+                title="Pre-Initialized Capacity: Total Workers",
+                period=Duration.minutes(1),
+                width=12,
+                left=[
+                    cw.MathExpression(
+                        expression="m1+m2+m3",
+                        label="Pre-Initialized Total Workers",
+                        period=Duration.minutes(1),
+                        using_metrics={
+                            "m1": preinit_driver_running_workers,
+                            "m2": preinit_executor_running_workers,
+                            "m3": idle_workers,
+                        },
+                    )
+                ],
+            ),
+            cw.GraphWidget(
+                title="Pre-Initialized Capacity: Worker Utilization %",
+                period=Duration.minutes(1),
+                width=12,
+                left=[
+                    cw.MathExpression(
+                        expression="100*((m1+m2)/(m1+m2+m3))",
+                        label="Pre-Initialized Capacity Worker Utilization %",
+                        period=Duration.minutes(1),
+                        using_metrics={
+                            "m1": preinit_driver_running_workers,
+                            "m2": preinit_executor_running_workers,
+                            "m3": idle_workers,
+                        },
+                    )
+                ],
+            ),
+        )
+        dashboard.add_widgets(
+            cw.GraphWidget(
+                title="Pre-Initialized Capacity: Idle Workers",
+                period=Duration.minutes(1),
+                width=12,
+                left=[idle_workers],
+            )
+        )
+        ## END: PRE-INITIALIZED CAPACITY METRICS
+
+        ## Dynamically generate metrics broken down by drivers, executors and capacity
+        for name, worker_type in zip(
+            ["Driver", "Executor"], ["Spark_Driver", "Spark_Executor"]
+        ):
+            dashboard.add_widgets(
+                cw.TextWidget(
+                    markdown=f"{name} Metrics\n---\n{name} metrics shows you the capacity used by Spark {name}s for Pre-Initialized and On-Demand capacity pools.",
+                    height=2,
+                    width=24,
+                )
+            )
+            for row in [
+                [
+                    {"metric": "RunningWorkerCount", "name": f"Running {name}s Count"},
+                    {"metric": "CPUAllocated", "name": "CPU Allocated"},
+                ],
+                [
+                    {"metric": "MemoryAllocated", "name": "Memory Allocated"},
+                    {"metric": "StorageAllocated", "name": "Storage Allocated"},
+                ],
+            ]:
+                dashboard.add_widgets(
+                    cw.GraphWidget(
+                        title=row[0]["name"],
+                        period=Duration.minutes(1),
+                        width=12,
+                        left=[
+                            cw.Metric(
+                                metric_name=row[0]["metric"],
+                                namespace="AWS/EMRServerless",
+                                dimensions_map={
+                                    "WorkerType": worker_type,
+                                    "CapacityAllocationType": "PreInitCapacity",
+                                    "ApplicationId": self.serverless_app.attr_application_id,
+                                },
+                                statistic="Sum",
+                                label="Pre-Initialized",
+                                period=Duration.minutes(1),
+                            ),
+                            cw.Metric(
+                                metric_name=row[0]["metric"],
+                                namespace="AWS/EMRServerless",
+                                dimensions_map={
+                                    "WorkerType": worker_type,
+                                    "CapacityAllocationType": "OnDemandCapacity",
+                                    "ApplicationId": self.serverless_app.attr_application_id,
+                                },
+                                statistic="Sum",
+                                label="OnDemand",
+                                period=Duration.minutes(1),
+                            ),
+                        ],
+                    ),
+                    cw.GraphWidget(
+                        title=row[1]["name"],
+                        period=Duration.minutes(1),
+                        width=12,
+                        left=[
+                            cw.Metric(
+                                metric_name=row[1]["metric"],
+                                namespace="AWS/EMRServerless",
+                                dimensions_map={
+                                    "WorkerType": worker_type,
+                                    "CapacityAllocationType": "PreInitCapacity",
+                                    "ApplicationId": self.serverless_app.attr_application_id,
+                                },
+                                statistic="Sum",
+                                label="Pre-Initialized",
+                                period=Duration.minutes(1),
+                            ),
+                            cw.Metric(
+                                metric_name=row[1]["metric"],
+                                namespace="AWS/EMRServerless",
+                                dimensions_map={
+                                    "WorkerType": worker_type,
+                                    "CapacityAllocationType": "OnDemandCapacity",
+                                    "ApplicationId": self.serverless_app.attr_application_id,
+                                },
+                                statistic="Sum",
+                                label="OnDemand",
+                                period=Duration.minutes(1),
+                            ),
+                        ],
+                    ),
+                )
+
+        return dashboard


### PR DESCRIPTION
EMR now publishes metrics to CloudWatch: https://docs.aws.amazon.com/emr/latest/EMR-Serverless-UserGuide/metrics.html

Also upgrades the CDK version to 2.44.0 to support GaugeViews and Stacked Graphs in CloudWatch Dashboards.