### PR TITLE
Add notes about docker buildx

### DIFF
--- a/examples/hive/README.md
+++ b/examples/hive/README.md
@@ -214,3 +214,7 @@ docker run --rm -d \
 ```shell
 docker stop emr-serverless-tez-ui
 ```
+
+## JSON Data
+
+The example job in this repository uses `OpenCSVSerde` to process CSV data. If you want to process JSON data, you can use the `org.apache.hadoop.hive.serde2.JsonSerDe` with EMR 6.x and `org.apache.hive.hcatalog.data.JsonSerDe` on EMR 5.x. `org.openx.data.jsonserde.JsonSerDe` can be used in either EMR release.

--- a/examples/pyspark/custom_python_version/README.md
+++ b/examples/pyspark/custom_python_version/README.md
@@ -10,8 +10,8 @@ Once created, we'll upload the new virtual environment and a sample Python scrip
 # Define a variable for code storage and job logs
 S3_BUCKET=<YOUR_S3_BUCKET>
 
-# Build our custom venv
-docker build --output . .
+# Build our custom venv with BuildKit backend
+DOCKER_BUILDKIT=1 docker build --output . .
 
 # Upload the artifacts to S3
 aws s3 cp pyspark_3.10.6.tar.gz     s3://${S3_BUCKET}/artifacts/pyspark/

--- a/examples/pyspark/dependencies/README.md
+++ b/examples/pyspark/dependencies/README.md
@@ -5,7 +5,7 @@ You can create isolated Python virtual environments to package multiple Python l
 ## Pre-requisites
 
 - Access to [EMR Serverless](https://docs.aws.amazon.com/emr/latest/EMR-Serverless-UserGuide/setting-up.html)
-- [Docker](https://www.docker.com/get-started)
+- [Docker](https://www.docker.com/get-started) with the [BuildKit backend](https://docs.docker.com/engine/reference/builder/#buildkit)
 - An S3 bucket in `us-east-1` and an IAM Role to run your EMR Serverless jobs
 
 > **Note**: If using Docker on Apple Silicon ensure you use `--platform linux/amd64`
@@ -29,7 +29,8 @@ All the commands below should be executed in this (`examples/pyspark/dependencie
 This command builds the included `Dockerfile` and exports the resulting `pyspark_ge.tar.gz` file to your local filesystem.
 
 ```shell
-docker build --output . .
+# Enable BuildKit backend
+DOCKER_BUILDKIT=1 docker build --output . .
 aws s3 cp pyspark_ge.tar.gz s3://${S3_BUCKET}/artifacts/pyspark/
 ```
 
@@ -125,7 +126,8 @@ To do this, we'll create a [`pom.xml`](./pom.xml) that specifies our dependencie
 1. Build an uberjar with your dependencies
 
 ```shell
-docker build -f Dockerfile.jars --output . .
+# Enable BuildKit backend
+DOCKER_BUILDKIT=1 docker build -f Dockerfile.jars --output . .
 ```
 
 This will create a `uber-jars-1.0-SNAPSHOT.jar` file locally that you will copy to S3 in the next step.

--- a/examples/pyspark/genomic/README.md
+++ b/examples/pyspark/genomic/README.md
@@ -13,7 +13,8 @@ In addition, we're _also_ going to create an uber-jar directly from the [Glow](h
 - In this directory, run the following command and it will build the Dockerfile and export `pyspark_glow.tar.gz` and `glow-spark3-assembly-1.1.2-SNAPSHOT.jar` to your local filesystem.
 
 ```shell
-docker build --output ./dependencies .
+# Enable BuildKit backend
+DOCKER_BUILDKIT=1 docker build --output ./dependencies .
 ```
 
 - Now copy those files to S3.
@@ -83,7 +84,8 @@ One other alternative I came up with while researching this is using a temp imag
 It uses an EMR on EKS image, so you'll need to [authenticate before building](https://docs.aws.amazon.com/emr/latest/EMR-on-EKS-DevelopmentGuide/docker-custom-images-steps.html).
 
 ```shell
-docker build -f Dockerfile.jars . --output jars
+# Enable BuildKit backend
+DOCKER_BUILDKIT=1 docker build -f Dockerfile.jars . --output jars
 ```
 
 This will export ~100 jars to your local filesystem, which you can upload to S3 and specificy via the `--jars` variable as a comma-delimited list.


### PR DESCRIPTION
The `--output` functionality utilized in the dependency examples requires the Docker BuildKit backend. 

This adds a note in the requirements and also updates the sample commands with the environment variable necessary to use BuildKit.