### PR TITLE
Now the EMRServerlessStartJobOperator has the countdown and check_int…

### DIFF
--- a/airflow/emr_serverless/hooks/emr.py
+++ b/airflow/emr_serverless/hooks/emr.py
@@ -24,6 +24,9 @@ from airflow.compat.functools import cached_property
 from airflow.exceptions import AirflowException
 from airflow.providers.amazon.aws.hooks.base_aws import AwsBaseHook
 
+DEFAULT_COUNTDOWN = 25 * 60
+DEFAULT_CHECK_INTERVAL_SECONDS = 60
+
 
 class EmrServerlessHook(AwsBaseHook):
     """
@@ -54,8 +57,8 @@ class EmrServerlessHook(AwsBaseHook):
         failure_states: Set,
         object_type: str,
         action: str,
-        countdown: int = 25 * 60,
-        check_interval_seconds: int = 60,
+        countdown: int = DEFAULT_COUNTDOWN,
+        check_interval_seconds: int = DEFAULT_CHECK_INTERVAL_SECONDS,
     ) -> None:
         """
         Will run the sensor until it turns True.

--- a/airflow/emr_serverless/operators/emr.py
+++ b/airflow/emr_serverless/operators/emr.py
@@ -19,7 +19,12 @@ import sys
 from typing import TYPE_CHECKING, Dict, Optional, Sequence
 from uuid import uuid4
 
-from emr_serverless.hooks.emr import EmrServerlessHook
+from emr_serverless.hooks.emr import (
+    EmrServerlessHook,
+    DEFAULT_COUNTDOWN,
+    DEFAULT_CHECK_INTERVAL_SECONDS,
+)
+
 from emr_serverless.sensors.emr import (
     EmrServerlessApplicationSensor,
     EmrServerlessJobSensor,
@@ -158,6 +163,8 @@ class EmrServerlessStartJobOperator(BaseOperator):
         config: Optional[dict] = None,
         wait_for_completion: bool = True,
         aws_conn_id: str = "aws_default",
+        countdown: int = DEFAULT_COUNTDOWN,
+        check_interval_seconds: int = DEFAULT_CHECK_INTERVAL_SECONDS,
         **kwargs,
     ):
         self.aws_conn_id = aws_conn_id
@@ -167,6 +174,8 @@ class EmrServerlessStartJobOperator(BaseOperator):
         self.configuration_overrides = configuration_overrides
         self.wait_for_completion = wait_for_completion
         self.config = config or {}
+        self.countdown = countdown
+        self.check_interval_seconds = check_interval_seconds
         super().__init__(**kwargs)
 
         self.client_request_token = client_request_token or str(uuid4())
@@ -221,6 +230,8 @@ class EmrServerlessStartJobOperator(BaseOperator):
                 failure_states=EmrServerlessJobSensor.FAILURE_STATES,
                 object_type="job",
                 action="run",
+                countdown=self.countdown,
+                check_interval_seconds=self.check_interval_seconds
             )
         return response["jobRunId"]
 


### PR DESCRIPTION

Now the EMRServerlessStartJobOperator has the countdown and check_interval_seconds parameters.

*Issue #, if available:*
https://github.com/aws-samples/emr-serverless-samples/issues/27

*Description of changes:*
When countdown and check_interval_seconds parameters are set, the hook waits the requested number of seconds for the job copmletion. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
