### PR TITLE
Update Airflow docs

### DIFF
--- a/airflow/README.md
+++ b/airflow/README.md
@@ -2,17 +2,20 @@
 
 As of `apache-airflow-providers-amazon==5.0.0`, the EMR Serverless Operator is now part of the official [Apache Airflow Amazon Provider](https://airflow.apache.org/docs/apache-airflow-providers-amazon/stable/index.html) and has been tested with open source Apache Airflow v2.2.2.
 
-It's recommended to use the official provider package as that will receive future updates.
+> **Warning** The operator in this repository is no longer maintained.
 
 ## Amazon Managed Workflows for Apache Airflow (MWAA)
 
-The most recent version (as of 2022-08-14) of the Operator is available as a semantic-versioned zip in this repository. In order to use it, just add the following line to your `requirements.txt` file.
+Amazon MWAA supports Airflow versions v2.2.2 and v2.4.3. As of release 6.1.0, the Amazon provider requires Airflow >= 2.3.0.
+
+Depending on the version of Airflow used in MWAA, the `requirements.txt` will look similar to this.
 
 ```
-emr_serverless @ https://github.com/aws-samples/emr-serverless-samples/releases/download/v1.0.1/mwaa_plugin.zip
+apache-airflow-providers-amazon==6.0.0
+boto3>=1.23.9
 ```
 
-Note that the operator depends on `boto3>=1.23.9`. This requirement is defined in the `setup.py` file.
+> **Note** `boto3>=1.23.9` is required for EMR Serverless support
 
 ## Example DAGs
 

--- a/airflow/dags/example_emr_serverless.py
+++ b/airflow/dags/example_emr_serverless.py
@@ -19,7 +19,7 @@ from datetime import datetime
 
 from airflow import DAG
 from airflow.models import Variable
-from emr_serverless.operators.emr import EmrServerlessStartJobOperator
+from airflow.providers.amazon.aws.operators.emr import EmrServerlessStartJobOperator
 
 APPLICATION_ID = Variable.get("emr_serverless_application_id")
 JOB_ROLE_ARN = Variable.get("emr_serverless_job_role")

--- a/airflow/dags/example_end_to_end.py
+++ b/airflow/dags/example_end_to_end.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from emr_serverless.operators.emr import (
+from airflow.providers.amazon.aws.operators.emr import (
     EmrServerlessCreateApplicationOperator,
     EmrServerlessDeleteApplicationOperator,
     EmrServerlessStartJobOperator,

--- a/cdk/emr-serverless-with-mwaa/app.py
+++ b/cdk/emr-serverless-with-mwaa/app.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 import aws_cdk as cdk
 
 from stacks.common import CommonStack

--- a/cdk/emr-serverless-with-mwaa/assets/airflow/dags/example_emr_serverless.py
+++ b/cdk/emr-serverless-with-mwaa/assets/airflow/dags/example_emr_serverless.py
@@ -20,7 +20,7 @@ from datetime import datetime
 
 from airflow import DAG
 from airflow.models import Variable
-from emr_serverless.operators.emr import EmrServerlessStartJobOperator
+from airflow.providers.amazon.aws.operators.emr import EmrServerlessStartJobOperator
 
 APPLICATION_ID = Variable.get("emr_serverless_application_id")
 JOB_ROLE_ARN = Variable.get("emr_serverless_job_role")

--- a/cdk/emr-serverless-with-mwaa/assets/airflow/dags/example_end_to_end.py
+++ b/cdk/emr-serverless-with-mwaa/assets/airflow/dags/example_end_to_end.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from emr_serverless.operators.emr import (
+from airflow.providers.amazon.aws.operators.emr import (
     EmrServerlessCreateApplicationOperator,
     EmrServerlessDeleteApplicationOperator,
     EmrServerlessStartJobOperator,

--- a/cdk/emr-serverless-with-mwaa/assets/airflow/requirements.txt
+++ b/cdk/emr-serverless-with-mwaa/assets/airflow/requirements.txt
@@ -1,1 +1,2 @@
-emr_serverless @ https://github.com/aws-samples/emr-serverless-samples/releases/download/v1.0.1/mwaa_plugin.zip
+apache-airflow-providers-amazon==7.0.0
+boto3>=1.23.9

--- a/cdk/emr-serverless-with-mwaa/stacks/mwaa.py
+++ b/cdk/emr-serverless-with-mwaa/stacks/mwaa.py
@@ -72,7 +72,7 @@ class MwaaStack(cdk.Stack):
             self,
             "airflow-v2",
             name=mwaa_name,
-            airflow_version="2.2.2",
+            airflow_version="2.4.3",
             dag_s3_path=f"dags/",
             source_bucket_arn=bucket.bucket_arn,
             execution_role_arn=mwaa_service_role.role_arn,


### PR DESCRIPTION
MWAA now supports updating the amazon provider package, so point folks towards the official operator instead of the one from this repo.

Also note that MWAA with Airflow 2.4.3 is now available. 