### PR TITLE
fix incorrect class path for Examples/Java/HelloWorld

### DIFF
--- a/examples/java/hello-world/src/main/java/HelloWorld.java
+++ b/examples/java/hello-world/src/main/java/HelloWorld.java
@@ -1,5 +1,3 @@
-package com.amazon.damon;
-
 import org.apache.spark.sql.SparkSession;
 
 


### PR DESCRIPTION
*Description of changes:*
remove `package com.amazon.damon;` from Examples/Java/HelloWorld as i…t cause an incorrect class path

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
