### PR TITLE
dbt on EMR Serverless with Spark Connect + token refresh

### DIFF
--- a/examples/dbt/.gitignore
+++ b/examples/dbt/.gitignore
@@ -1,0 +1,6 @@
+__pycache__/
+*.pyc
+dbt_project/target/
+dbt_project/logs/
+dbt_packages/
+.user.yml

--- a/examples/dbt/README.md
+++ b/examples/dbt/README.md
@@ -33,7 +33,17 @@ Either via `~/.aws/credentials`, `AWS_PROFILE` env var, or instance/task role.
 
 ### 3. Make sure your EMR Serverless application has sessions enabled
 
-EMR Serverless applications created on **release 7.13 or later** have interactive sessions enabled by default. To confirm for an existing application:
+Interactive sessions must be enabled on the application. The simplest path is to create the application with `sessionEnabled=true`:
+
+```bash
+aws emr-serverless create-application \\
+    --name dbt-spark-connect \\
+    --release-label emr-7.13.0 \\
+    --type SPARK \\
+    --interactive-configuration '{"sessionEnabled":true}'
+```
+
+To verify on an existing application:
 
 ```bash
 aws emr-serverless get-application \\
@@ -41,7 +51,7 @@ aws emr-serverless get-application \\
     --query 'application.interactiveConfiguration'
 ```
 
-If the response does not show `"sessionEnabled": true`, update the application (it must be in `STOPPED` state) with the relevant AWS CLI or console flow before proceeding.
+If the response does not show `"sessionEnabled": true`, stop the application and run `update-application` with the same `--interactive-configuration '{"sessionEnabled":true}'` before proceeding.
 
 ### 4. Run dbt
 

--- a/examples/dbt/README.md
+++ b/examples/dbt/README.md
@@ -12,8 +12,8 @@ EMR Serverless sessions themselves live up to 24 hours — it's only the auth to
 
 Two small Python modules bundled in this example:
 
-1. **`emrs_custom_spark_connect/`** — a gRPC channel interceptor that, before each outbound RPC, checks token expiry and calls `GetSessionEndpoint` for a fresh token when needed. Authored by Vikrant Kumar (EMR Serverless team); re-used here and expected to be published as a standalone package in the future.
-2. **`emrs_sparkconnect_autopatch.py`** — a ~50-line monkey-patch that plugs the interceptor into PySpark's default Spark Connect channel builder, so stock clients like dbt (which don't know anything about EMR-S) get transparent token refresh just by importing this module.
+1. **`emrs_custom_spark_connect/`** — a gRPC channel interceptor that, before each outbound RPC, checks token expiry and calls `GetSessionEndpoint` for a fresh token when needed.
+2. **`emrs_sparkconnect_autopatch.py`** — a ~50-line patch that plugs the interceptor into PySpark's default Spark Connect channel builder, so stock clients like dbt (which don't know anything about EMR-S) get transparent token refresh just by importing this module.
 
 The SparkConnect session stays alive across token rotations — no teardown, no state loss. dbt-spark is stock, unmodified.
 
@@ -33,13 +33,15 @@ Either via `~/.aws/credentials`, `AWS_PROFILE` env var, or instance/task role.
 
 ### 3. Make sure your EMR Serverless application has sessions enabled
 
+EMR Serverless applications created on **release 7.13 or later** have interactive sessions enabled by default. To confirm for an existing application:
+
 ```bash
-aws emr-serverless update-application \\
+aws emr-serverless get-application \\
     --application-id <APP_ID> \\
-    --interactive-configuration '{"sessionEnabled":true}'
+    --query 'application.interactiveConfiguration'
 ```
 
-The application must be in `STOPPED` state to update this config.
+If the response does not show `"sessionEnabled": true`, update the application (it must be in `STOPPED` state) with the relevant AWS CLI or console flow before proceeding.
 
 ### 4. Run dbt
 
@@ -102,23 +104,12 @@ View materializations are unaffected.
 
 Without the autopatch shim, the same test fails at t+62 min with `StatusCode.UNKNOWN / "Stream removed" / "Received incorrect session identifier"`.
 
-## Upstream direction
-
-This sample uses a runtime monkey-patch because there is no official PySpark hook to inject a gRPC interceptor when building a Spark Connect channel from a `SPARK_REMOTE` URL. The `emrs_custom_spark_connect` module bundled here is expected to be published as a standalone package by the EMR Serverless team. Once that happens, this example will be updated to depend on the published package and drop the bundled copy.
-
-Longer-term we're also exploring contributing a `spark_connect` method to [`dbt-adapters`](https://github.com/dbt-labs/dbt-adapters) that accepts a channel builder natively, which would remove the need for monkey-patching.
-
 ## Files
 
 | File | Purpose |
 |---|---|
 | `emrs_custom_spark_connect/` | gRPC interceptor + Spark Connect session helper (bundled temporarily; will be a separate pip package) |
-| `emrs_sparkconnect_autopatch.py` | Monkey-patch that plugs the interceptor into stock PySpark |
+| `emrs_sparkconnect_autopatch.py` | Patch that plugs the interceptor into stock PySpark |
 | `run_dbt.py` | End-to-end runner — starts session, runs dbt, tears down |
 | `profiles.yml` | Sample dbt profile (type: spark, method: session) |
 | `dbt_project/` | Minimal dbt project with one view model |
-
-## Credits
-
-- **Vikrant (AWS)** — authored the gRPC channel interceptor (`emrs_custom_spark_connect`) and validated it with 90-minute and 2.5-hour long-query tests on EMR-S beta.
-- This sample combines that library with a thin monkey-patch so stock PySpark clients (dbt, Jupyter, custom Python scripts) get transparent refresh with zero client-side code changes.

--- a/examples/dbt/README.md
+++ b/examples/dbt/README.md
@@ -22,7 +22,7 @@ The SparkConnect session stays alive across token rotations — no teardown, no 
 ### 1. Install dependencies
 
 ```bash
-pip install dbt-core "dbt-spark[session]" "pyspark[connect]>=3.5" boto3
+pip install dbt-core "dbt-spark[session]" "pyspark[connect]>=3.5,<4" boto3
 # Python 3.12+ also needs:
 pip install "setuptools<81"
 ```

--- a/examples/dbt/README.md
+++ b/examples/dbt/README.md
@@ -120,5 +120,5 @@ Longer-term we're also exploring contributing a `spark_connect` method to [`dbt-
 
 ## Credits
 
-- **Vikrant Kumar** — authored the gRPC channel interceptor (`emrs_custom_spark_connect`) and validated it with 90-minute and 2.5-hour long-query tests on EMR-S beta.
+- **Vikrant (AWS)** — authored the gRPC channel interceptor (`emrs_custom_spark_connect`) and validated it with 90-minute and 2.5-hour long-query tests on EMR-S beta.
 - This sample combines that library with a thin monkey-patch so stock PySpark clients (dbt, Jupyter, custom Python scripts) get transparent refresh with zero client-side code changes.

--- a/examples/dbt/README.md
+++ b/examples/dbt/README.md
@@ -1,0 +1,124 @@
+# dbt on EMR Serverless with Spark Connect
+
+This example shows how to run **dbt-core** against an **Amazon EMR Serverless** application using Spark Connect, with automatic auth token refresh so long-running dbt projects survive past the 1-hour token TTL.
+
+## The problem
+
+EMR Serverless Spark Connect sessions authenticate each gRPC request with an `x-aws-proxy-auth` token embedded in the `SPARK_REMOTE` URL. The token expires after **1 hour**. Stock PySpark has no mechanism to refresh it, so a dbt project that runs longer than ~60 minutes fails mid-run with `StatusCode.UNKNOWN / "Stream removed"`.
+
+EMR Serverless sessions themselves live up to 24 hours — it's only the auth token that's short-lived.
+
+## The solution
+
+Two small Python modules bundled in this example:
+
+1. **`emrs_custom_spark_connect/`** — a gRPC channel interceptor that, before each outbound RPC, checks token expiry and calls `GetSessionEndpoint` for a fresh token when needed. Authored by Vikrant Kumar (EMR Serverless team); re-used here and expected to be published as a standalone package in the future.
+2. **`emrs_sparkconnect_autopatch.py`** — a ~50-line monkey-patch that plugs the interceptor into PySpark's default Spark Connect channel builder, so stock clients like dbt (which don't know anything about EMR-S) get transparent token refresh just by importing this module.
+
+The SparkConnect session stays alive across token rotations — no teardown, no state loss. dbt-spark is stock, unmodified.
+
+## Quick start
+
+### 1. Install dependencies
+
+```bash
+pip install dbt-core "dbt-spark[session]" "pyspark[connect]>=3.5" boto3
+# Python 3.12+ also needs:
+pip install "setuptools<81"
+```
+
+### 2. Configure AWS credentials
+
+Either via `~/.aws/credentials`, `AWS_PROFILE` env var, or instance/task role.
+
+### 3. Make sure your EMR Serverless application has sessions enabled
+
+```bash
+aws emr-serverless update-application \\
+    --application-id <APP_ID> \\
+    --interactive-configuration '{"sessionEnabled":true}'
+```
+
+The application must be in `STOPPED` state to update this config.
+
+### 4. Run dbt
+
+```bash
+python run_dbt.py \\
+    --application-id <APP_ID> \\
+    --execution-role-arn <ROLE_ARN> \\
+    --region us-east-1
+```
+
+The script starts an EMR-S session, waits for it to be ready, sets `SPARK_REMOTE`, invokes dbt, and terminates the session on exit.
+
+## How customers adapt this to their own projects
+
+The bundled shim and interceptor assume **zero changes** to your dbt project. To use the pattern with your own dbt models:
+
+1. Copy both `emrs_sparkconnect_autopatch.py` and the `emrs_custom_spark_connect/` directory into your Python path.
+2. In your dbt runner script, `import emrs_sparkconnect_autopatch` **before** any pyspark import and before invoking dbt.
+3. Set env vars before running dbt:
+   - `SPARK_REMOTE` — the EMR-S Spark Connect URL (returned by `GetSessionEndpoint`)
+   - `EMRS_APPLICATION_ID` — used by the interceptor to refresh the token
+   - `AWS_REGION` — used by the boto3 client
+4. Your `profiles.yml` uses `type: spark`, `method: session`, `host: localhost` (stock dbt-spark config).
+
+No dbt-spark fork, no dbt adapter changes, no custom connection method.
+
+## Important notes
+
+### Session idle timeout
+
+By default EMR-S sessions auto-terminate after 15 minutes of idle time. If your dbt project has gaps longer than that (e.g., waiting on upstream data), set `idleTimeoutMinutes` high enough to cover the longest gap. The example uses 120 minutes.
+
+### `enableHiveSupport()` is a no-op in Spark Connect mode
+
+When `SPARK_REMOTE` is set, PySpark's `SparkSession.builder.enableHiveSupport().getOrCreate()` routes through the Spark Connect client, which does not honor `enableHiveSupport()`. You'll see a harmless warning:
+
+```
+UserWarning: Cannot modify the value of a static config: spark.sql.catalogImplementation.
+```
+
+Consequence: `CREATE TABLE AS SELECT` without an explicit `file_format` fails with `NOT_SUPPORTED_COMMAND_WITHOUT_HIVE_SUPPORT`. Either:
+
+- Add `{{ config(file_format='parquet') }}` to each table model, or
+- Set `spark.sql.catalogImplementation=hive` at the EMR-S application level (application-wide runtime config)
+
+View materializations are unaffected.
+
+### Session lifecycle is your responsibility
+
+`run_dbt.py` starts and terminates the EMR-S session for each invocation. For production use, you'll likely want to reuse a session across multiple dbt invocations (run, test, snapshot) to avoid startup overhead. The same env vars work — just keep the session alive between calls.
+
+## Validated
+
+| Elapsed since session start | dbt run result |
+|---|---|
+| t+0 min | ✅ PASS |
+| t+55 min | ✅ PASS |
+| **t+62 min (past 1-hr token TTL)** | ✅ **PASS** |
+| t+68 min | ✅ PASS |
+
+Without the autopatch shim, the same test fails at t+62 min with `StatusCode.UNKNOWN / "Stream removed" / "Received incorrect session identifier"`.
+
+## Upstream direction
+
+This sample uses a runtime monkey-patch because there is no official PySpark hook to inject a gRPC interceptor when building a Spark Connect channel from a `SPARK_REMOTE` URL. The `emrs_custom_spark_connect` module bundled here is expected to be published as a standalone package by the EMR Serverless team. Once that happens, this example will be updated to depend on the published package and drop the bundled copy.
+
+Longer-term we're also exploring contributing a `spark_connect` method to [`dbt-adapters`](https://github.com/dbt-labs/dbt-adapters) that accepts a channel builder natively, which would remove the need for monkey-patching.
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `emrs_custom_spark_connect/` | gRPC interceptor + Spark Connect session helper (bundled temporarily; will be a separate pip package) |
+| `emrs_sparkconnect_autopatch.py` | Monkey-patch that plugs the interceptor into stock PySpark |
+| `run_dbt.py` | End-to-end runner — starts session, runs dbt, tears down |
+| `profiles.yml` | Sample dbt profile (type: spark, method: session) |
+| `dbt_project/` | Minimal dbt project with one view model |
+
+## Credits
+
+- **Vikrant Kumar** — authored the gRPC channel interceptor (`emrs_custom_spark_connect`) and validated it with 90-minute and 2.5-hour long-query tests on EMR-S beta.
+- This sample combines that library with a thin monkey-patch so stock PySpark clients (dbt, Jupyter, custom Python scripts) get transparent refresh with zero client-side code changes.

--- a/examples/dbt/dbt_project/dbt_project.yml
+++ b/examples/dbt/dbt_project/dbt_project.yml
@@ -1,0 +1,9 @@
+name: 'emrs_demo'
+version: '1.0.0'
+profile: 'emrs_demo'
+model-paths: ["models"]
+target-path: "target"
+clean-targets: ["target", "dbt_packages"]
+models:
+  emrs_demo:
+    +materialized: view

--- a/examples/dbt/dbt_project/models/ping.sql
+++ b/examples/dbt/dbt_project/models/ping.sql
@@ -1,0 +1,2 @@
+-- Minimal sample model. Runs on EMR Serverless via Spark Connect.
+select current_timestamp() as ts, 1 as n

--- a/examples/dbt/emrs_custom_spark_connect/__init__.py
+++ b/examples/dbt/emrs_custom_spark_connect/__init__.py
@@ -1,0 +1,6 @@
+"""EMR Serverless Spark Connect client with automatic token refresh."""
+
+from .interceptors import CustomChannelBuilder, SparkConnectGRPCInterceptor
+from .session import EMRServerlessSparkSession
+
+__all__ = ["CustomChannelBuilder", "SparkConnectGRPCInterceptor", "EMRServerlessSparkSession"]

--- a/examples/dbt/emrs_custom_spark_connect/interceptors.py
+++ b/examples/dbt/emrs_custom_spark_connect/interceptors.py
@@ -1,0 +1,108 @@
+"""
+EMR Serverless Spark Connect — gRPC Interceptor for Token Refresh
+
+Intercepts every outgoing gRPC call, checks token expiry, refreshes via
+GetSessionEndpoint if needed, and injects the fresh token as x-aws-proxy-auth metadata.
+"""
+
+import datetime
+import logging
+from collections import namedtuple
+
+import grpc
+from pyspark.sql.connect.client import ChannelBuilder
+
+logger = logging.getLogger("EMRServerlessSparkConnect")
+
+# namedtuple to create new ClientCallDetails with updated metadata
+_ClientCallDetails = namedtuple(
+    "_ClientCallDetails",
+    ("method", "timeout", "metadata", "credentials", "wait_for_ready", "compression"),
+)
+
+
+class _ClientCallDetails(_ClientCallDetails, grpc.ClientCallDetails):
+    pass
+
+
+class SparkConnectGRPCInterceptor(
+    grpc.UnaryUnaryClientInterceptor,
+    grpc.UnaryStreamClientInterceptor,
+    grpc.StreamUnaryClientInterceptor,
+    grpc.StreamStreamClientInterceptor,
+):
+    """Intercepts gRPC calls to inject a fresh EMR Serverless auth token."""
+
+    def __init__(self, application_id: str, session_id: str, emrs_client):
+        self.application_id = application_id
+        self.session_id = session_id
+        self.emrs_client = emrs_client
+        self.cached_token = None
+        # Refresh 5 minutes before actual expiry
+        self.early_refresh_margin = 5 * 60
+        self.cache_expiration_time = datetime.datetime.min.replace(tzinfo=datetime.timezone.utc)
+
+    def _refresh_token(self):
+        logger.info(f"Refreshing token for session {self.session_id}")
+        try:
+            response = self.emrs_client.get_session_endpoint(
+                applicationId=self.application_id,
+                sessionId=self.session_id,
+            )
+            self.cached_token = response["authToken"]
+            expires_at = response["authTokenExpiresAt"]
+            # Handle both datetime and string responses
+            if isinstance(expires_at, str):
+                expires_at = datetime.datetime.fromisoformat(expires_at)
+            if expires_at.tzinfo is None:
+                expires_at = expires_at.replace(tzinfo=datetime.timezone.utc)
+            self.cache_expiration_time = expires_at - datetime.timedelta(seconds=self.early_refresh_margin)
+            logger.info(f"Token refreshed. Next refresh at {self.cache_expiration_time}")
+        except Exception as e:
+            logger.error(f"Failed to refresh token for session {self.session_id}: {e}")
+            raise
+
+    def _with_metadata(self, client_call_details):
+        now = datetime.datetime.now(datetime.timezone.utc)
+        if self.cache_expiration_time < now:
+            self._refresh_token()
+
+        metadata = dict(client_call_details.metadata or {})
+        metadata["x-aws-proxy-auth"] = self.cached_token
+        return _ClientCallDetails(
+            method=client_call_details.method,
+            timeout=client_call_details.timeout,
+            metadata=list(metadata.items()),
+            credentials=client_call_details.credentials,
+            wait_for_ready=client_call_details.wait_for_ready,
+            compression=client_call_details.compression,
+        )
+
+    def intercept_unary_unary(self, continuation, client_call_details, request):
+        return continuation(self._with_metadata(client_call_details), request)
+
+    def intercept_unary_stream(self, continuation, client_call_details, request):
+        return continuation(self._with_metadata(client_call_details), request)
+
+    def intercept_stream_unary(self, continuation, client_call_details, request_iterator):
+        return continuation(self._with_metadata(client_call_details), request_iterator)
+
+    def intercept_stream_stream(self, continuation, client_call_details, request_iterator):
+        return continuation(self._with_metadata(client_call_details), request_iterator)
+
+
+class CustomChannelBuilder(ChannelBuilder):
+    """Extends PySpark's ChannelBuilder to add the token-refresh interceptor."""
+
+    def __init__(self, application_id: str, emrs_session_id: str, url: str, emrs_client):
+        super().__init__(url)
+        self._application_id = application_id
+        self._emrs_session_id = emrs_session_id
+        self._emrs_client = emrs_client
+
+    def toChannel(self) -> grpc.Channel:
+        channel = super().toChannel()
+        interceptor = SparkConnectGRPCInterceptor(
+            self._application_id, self._emrs_session_id, self._emrs_client
+        )
+        return grpc.intercept_channel(channel, interceptor)

--- a/examples/dbt/emrs_custom_spark_connect/session.py
+++ b/examples/dbt/emrs_custom_spark_connect/session.py
@@ -1,0 +1,152 @@
+"""
+EMR Serverless Spark Connect — Session Manager (Option 2: high-level wrapper)
+
+Manages the full session lifecycle: start → wait → get-endpoint → create SparkSession
+with automatic token refresh.
+"""
+
+import logging
+import time
+
+import boto3
+from pyspark.sql.connect.session import SparkSession
+
+from .interceptors import CustomChannelBuilder
+
+logger = logging.getLogger("EMRServerlessSparkConnect")
+
+
+class EMRServerlessSparkSession:
+    """High-level wrapper that manages EMR Serverless session lifecycle + token refresh."""
+
+    def __init__(self, application_id, session_id, spark_session, emrs_client):
+        self.application_id = application_id
+        self.session_id = session_id
+        self.spark = spark_session
+        self.emrs_client = emrs_client
+
+    @classmethod
+    def create(
+        cls,
+        application_id: str,
+        execution_role_arn: str,
+        region: str = "us-west-2",
+        endpoint_url: str = None,
+        session_name: str = "spark-connect-session",
+        idle_timeout_minutes: int = 15,
+        max_wait: int = 900,
+        spark_conf: dict = None,
+    ) -> "EMRServerlessSparkSession":
+        """Create a SparkSession with automatic token refresh.
+
+        Args:
+            application_id: EMR Serverless application ID
+            execution_role_arn: IAM role ARN for execution
+            region: AWS region
+            endpoint_url: Custom EMR Serverless endpoint URL (for beta/gamma)
+            session_name: Name for the session
+            idle_timeout_minutes: Session idle timeout
+            max_wait: Max seconds to wait for session ready
+            spark_conf: Optional dict of spark config overrides
+
+        Returns:
+            EMRServerlessSparkSession wrapping a SparkSession with token auto-refresh
+        """
+        client_kwargs = {"region_name": region}
+        if endpoint_url:
+            client_kwargs["endpoint_url"] = endpoint_url
+        emrs_client = boto3.client("emr-serverless", **client_kwargs)
+
+        # 1. Start session
+        start_kwargs = {
+            "applicationId": application_id,
+            "name": session_name,
+            "executionRoleArn": execution_role_arn,
+            "idleTimeoutMinutes": idle_timeout_minutes,
+        }
+        if spark_conf:
+            start_kwargs["configurationOverrides"] = {
+                "runtimeConfiguration": [{
+                    "classification": "spark-defaults",
+                    "properties": spark_conf,
+                }]
+            }
+        resp = emrs_client.start_session(**start_kwargs)
+        session_id = resp["sessionId"]
+        logger.info(f"Started session {session_id}")
+
+        # 2. Wait for READY
+        _wait_for_ready(emrs_client, application_id, session_id, max_wait)
+
+        # 3. Get endpoint + token
+        ep_resp = emrs_client.get_session_endpoint(
+            applicationId=application_id, sessionId=session_id
+        )
+        endpoint = ep_resp["endpoint"]
+        token = ep_resp["authToken"]
+
+        # 4. Build Spark Connect URL
+        # endpoint is like https://SESSION_ID.s.emr-serverless-services-beta.REGION.amazonaws.com
+        # convert to sc:// format
+        sc_url = endpoint.replace("https://", "sc://", 1)
+        spark_connect_url = f"{sc_url}:443/;use_ssl=true;x-aws-proxy-auth={token}"
+        logger.info(f"Spark Connect URL: {spark_connect_url}")
+
+        # 5. Create SparkSession with custom channel builder (token auto-refresh)
+        channel_builder = CustomChannelBuilder(
+            application_id=application_id,
+            emrs_session_id=session_id,
+            url=spark_connect_url,
+            emrs_client=emrs_client,
+        )
+        spark = SparkSession.builder.channelBuilder(channel_builder).getOrCreate()
+        logger.info("SparkSession created with token auto-refresh")
+
+        return cls(application_id, session_id, spark, emrs_client)
+
+    def stop(self):
+        """Stop the SparkSession and the EMR Serverless session."""
+        if self.spark:
+            try:
+                self.spark.stop()
+            except Exception as e:
+                logger.error(f"Error stopping SparkSession: {e}")
+            self.spark = None
+
+        if self.session_id:
+            try:
+                self.emrs_client.terminate_session(
+                    applicationId=self.application_id, sessionId=self.session_id
+                )
+                logger.info(f"Stopped session {self.session_id}")
+            except Exception as e:
+                logger.error(f"Error stopping session {self.session_id}: {e}")
+            self.session_id = None
+
+    def __getattr__(self, name):
+        """Delegate attribute access to the underlying SparkSession."""
+        return getattr(self.spark, name)
+
+
+def _wait_for_ready(emrs_client, application_id, session_id, max_wait):
+    """Poll GetSession until state is READY or terminal."""
+    start = time.time()
+    last_state = None
+    while True:
+        elapsed = time.time() - start
+        if elapsed >= max_wait:
+            raise TimeoutError(f"Session {session_id} not ready after {max_wait}s")
+
+        resp = emrs_client.get_session(applicationId=application_id, sessionId=session_id)
+        state = resp["session"]["state"]
+
+        if state != last_state:
+            logger.info(f"Session {session_id} state: {state}")
+            last_state = state
+
+        if state in ("READY", "IDLE", "STARTED"):
+            return
+        if state in ("FAILED", "TERMINATED", "STOPPED"):
+            raise RuntimeError(f"Session {session_id} reached terminal state: {state}")
+
+        time.sleep(2)

--- a/examples/dbt/emrs_sparkconnect_autopatch.py
+++ b/examples/dbt/emrs_sparkconnect_autopatch.py
@@ -1,10 +1,10 @@
-"""Monkey-patch pyspark's Spark Connect ChannelBuilder so every channel built
+"""Patch pyspark's Spark Connect ChannelBuilder so every channel built
 from a SPARK_REMOTE URL pointing at EMR Serverless gets the token-refresh
 interceptor attached automatically.
 
-Re-uses the interceptor implementation from `emrs_custom_spark_connect`
-(authored by Vikrant Kumar, bundled alongside this file for convenience until
-the upstream package is published).
+Re-uses the interceptor implementation from `emrs_custom_spark_connect`,
+bundled alongside this file for convenience until the upstream package is
+published.
 
 Usage (dbt or any stock Spark Connect client):
 

--- a/examples/dbt/emrs_sparkconnect_autopatch.py
+++ b/examples/dbt/emrs_sparkconnect_autopatch.py
@@ -1,0 +1,69 @@
+"""Monkey-patch pyspark's Spark Connect ChannelBuilder so every channel built
+from a SPARK_REMOTE URL pointing at EMR Serverless gets the token-refresh
+interceptor attached automatically.
+
+Re-uses the interceptor implementation from `emrs_custom_spark_connect`
+(authored by Vikrant Kumar, bundled alongside this file for convenience until
+the upstream package is published).
+
+Usage (dbt or any stock Spark Connect client):
+
+    export SPARK_REMOTE="sc://<sid>.s.emr-serverless-services.<region>.amazonaws.com:443/;use_ssl=true;x-aws-proxy-auth=<tok>"
+    export EMRS_APPLICATION_ID="<app-id>"
+    export AWS_REGION="<region>"
+
+    python -c "import emrs_sparkconnect_autopatch; from dbt.cli.main import dbtRunner; dbtRunner().invoke(['run'])"
+
+The import patches pyspark.sql.connect.client.ChannelBuilder.toChannel to
+detect EMR-S URLs and swap in a channel with the refresh interceptor. Non-EMR-S
+hosts pass through unchanged.
+"""
+import logging
+import os
+import re
+
+import boto3
+import grpc
+from pyspark.sql.connect.client import ChannelBuilder as _ChannelBuilder
+
+from emrs_custom_spark_connect.interceptors import SparkConnectGRPCInterceptor
+
+logger = logging.getLogger("emrs_sparkconnect_autopatch")
+
+_ORIG_TO_CHANNEL = _ChannelBuilder.toChannel
+_EMRS_HOST_RE = re.compile(
+    r"^([a-z0-9]+)\.s\.emr-serverless-services[\-\.a-z0-9]*\.amazonaws\.com$"
+)
+
+
+def _patched_to_channel(self) -> grpc.Channel:
+    channel = _ORIG_TO_CHANNEL(self)
+    m = _EMRS_HOST_RE.match(self.host)
+    if not m:
+        return channel  # not EMR-S, pass through
+
+    session_id = m.group(1)
+    application_id = os.environ.get("EMRS_APPLICATION_ID")
+    if not application_id:
+        import warnings
+        warnings.warn(
+            "EMR-S Spark Connect URL detected but EMRS_APPLICATION_ID env var is "
+            "not set; token auto-refresh will not be active."
+        )
+        return channel
+
+    region = (
+        os.environ.get("AWS_REGION")
+        or os.environ.get("AWS_DEFAULT_REGION")
+        or "us-east-1"
+    )
+    emrs_client = boto3.client("emr-serverless", region_name=region)
+    interceptor = SparkConnectGRPCInterceptor(application_id, session_id, emrs_client)
+    logger.info(
+        "Installed token-refresh interceptor for EMR-S app=%s session=%s",
+        application_id, session_id,
+    )
+    return grpc.intercept_channel(channel, interceptor)
+
+
+_ChannelBuilder.toChannel = _patched_to_channel

--- a/examples/dbt/profiles.yml
+++ b/examples/dbt/profiles.yml
@@ -1,0 +1,8 @@
+emrs_demo:
+  target: dev
+  outputs:
+    dev:
+      type: spark
+      method: session
+      schema: default
+      host: localhost

--- a/examples/dbt/run_dbt.py
+++ b/examples/dbt/run_dbt.py
@@ -3,7 +3,7 @@ run dbt against it with automatic token refresh, then tear down.
 
 This script demonstrates that stock dbt-core + dbt-spark works with EMR-S
 Spark Connect beyond the 1-hour auth token TTL, by importing a small
-monkey-patch shim (`emrs_sparkconnect_autopatch`) before dbt runs.
+patch shim (`emrs_sparkconnect_autopatch`) before dbt runs.
 
 Usage:
     python run_dbt.py \\
@@ -25,7 +25,7 @@ from pathlib import Path
 HERE = Path(__file__).resolve().parent
 sys.path.insert(0, str(HERE))
 
-# Install the monkey-patch before any pyspark Spark Connect session is built.
+# Install the patch before any pyspark Spark Connect session is built.
 import emrs_sparkconnect_autopatch  # noqa: E402, F401
 
 import boto3  # noqa: E402

--- a/examples/dbt/run_dbt.py
+++ b/examples/dbt/run_dbt.py
@@ -12,7 +12,7 @@ Usage:
         --region us-east-1
 
 Pre-requisites:
-    pip install dbt-core "dbt-spark[session]" "pyspark[connect]>=3.5" boto3
+    pip install dbt-core "dbt-spark[session]" "pyspark[connect]>=3.5,<4" boto3
     # If on Python 3.12+:
     pip install "setuptools<81"
 """

--- a/examples/dbt/run_dbt.py
+++ b/examples/dbt/run_dbt.py
@@ -1,0 +1,103 @@
+"""End-to-end example: start an EMR Serverless Spark Connect session,
+run dbt against it with automatic token refresh, then tear down.
+
+This script demonstrates that stock dbt-core + dbt-spark works with EMR-S
+Spark Connect beyond the 1-hour auth token TTL, by importing a small
+monkey-patch shim (`emrs_sparkconnect_autopatch`) before dbt runs.
+
+Usage:
+    python run_dbt.py \\
+        --application-id <APP_ID> \\
+        --execution-role-arn <ROLE_ARN> \\
+        --region us-east-1
+
+Pre-requisites:
+    pip install dbt-core "dbt-spark[session]" "pyspark[connect]>=3.5" boto3
+    # If on Python 3.12+:
+    pip install "setuptools<81"
+"""
+import argparse
+import os
+import sys
+import time
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(HERE))
+
+# Install the monkey-patch before any pyspark Spark Connect session is built.
+import emrs_sparkconnect_autopatch  # noqa: E402, F401
+
+import boto3  # noqa: E402
+
+
+def wait_for_session(emrs, app_id, session_id, timeout=300):
+    start = time.time()
+    while True:
+        state = emrs.get_session(
+            applicationId=app_id, sessionId=session_id
+        )["session"]["state"]
+        if state in ("STARTED", "IDLE", "READY"):
+            return
+        if state in ("FAILED", "TERMINATED"):
+            raise RuntimeError(f"Session reached terminal state: {state}")
+        if time.time() - start > timeout:
+            raise TimeoutError(f"Session not ready in {timeout}s (last state: {state})")
+        time.sleep(5)
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument("--application-id", required=True)
+    p.add_argument("--execution-role-arn", required=True)
+    p.add_argument("--region", default="us-east-1")
+    p.add_argument("--idle-timeout-minutes", type=int, default=120,
+                   help="EMR-S session idle timeout; set high enough to cover gaps between dbt runs.")
+    p.add_argument("--project-dir", default=str(HERE / "dbt_project"))
+    p.add_argument("--profiles-dir", default=str(HERE))
+    p.add_argument("--dbt-command", default="run",
+                   help="dbt subcommand (run, test, build, debug...)")
+    args = p.parse_args()
+
+    os.environ["AWS_REGION"] = args.region
+    os.environ["EMRS_APPLICATION_ID"] = args.application_id
+    os.environ["DBT_PROFILES_DIR"] = args.profiles_dir
+
+    emrs = boto3.client("emr-serverless", region_name=args.region)
+
+    # Start EMR-S session
+    resp = emrs.start_session(
+        applicationId=args.application_id,
+        executionRoleArn=args.execution_role_arn,
+        idleTimeoutMinutes=args.idle_timeout_minutes,
+    )
+    session_id = resp["sessionId"]
+    print(f"Started EMR-S session: {session_id}")
+
+    try:
+        wait_for_session(emrs, args.application_id, session_id)
+        ep = emrs.get_session_endpoint(
+            applicationId=args.application_id, sessionId=session_id
+        )
+        url = ep["endpoint"].replace("https", "sc") + ":443/;use_ssl=true;"
+        url += f"x-aws-proxy-auth={ep['authToken']}"
+        os.environ["SPARK_REMOTE"] = url
+        print("SPARK_REMOTE set; autopatch will install refresh interceptor on first gRPC call.")
+
+        # Import dbt after env is set.
+        from dbt.cli.main import dbtRunner
+        result = dbtRunner().invoke([args.dbt_command, "--project-dir", args.project_dir])
+        print(f"dbt {args.dbt_command} success={result.success}")
+        sys.exit(0 if result.success else 1)
+    finally:
+        try:
+            emrs.terminate_session(
+                applicationId=args.application_id, sessionId=session_id
+            )
+            print(f"Terminated session {session_id}")
+        except Exception as e:
+            print(f"Warning: failed to terminate session {session_id}: {e}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## dbt on EMR Serverless with Spark Connect + token refresh

Adds `examples/dbt/` — demonstrates running stock dbt-core against EMR Serverless Spark Connect with automatic auth token refresh past the 1-hour token TTL.

### What's included

- `emrs_custom_spark_connect/` — gRPC interceptor that refreshes the `x-aws-proxy-auth` token before expiry (credit: Vikrant)
- `emrs_sparkconnect_autopatch.py` — monkey-patch that plugs the interceptor into stock pyspark's `SPARK_REMOTE` path
- `run_dbt.py` — end-to-end runner (start session → run dbt → terminate)
- Sample dbt project + profiles.yml

### Key points

- Zero changes to dbt-spark or pyspark on disk
- Validated on prod EMR Serverless (us-east-1, emr-7.13.0): `dbt run` passes at t+0, t+55, t+62 (past 1-hr boundary), t+68 min
- Without the autopatch, same test fails at t+62 with `UNKNOWN / Stream removed`

### Customer action

`pip install` dependencies, set 3 env vars, add 1 `import` line. Everything else in their dbt project stays the same.
