### PR TITLE
chore(airflow): bump Airflow example to 2.11.x, fix cached_property imports

### DIFF
--- a/airflow/emr_serverless/hooks/emr.py
+++ b/airflow/emr_serverless/hooks/emr.py
@@ -17,12 +17,12 @@
 # under the License.
 from __future__ import annotations
 
+from functools import cached_property
 from time import sleep
 from typing import Any, Callable
 
 from botocore.config import Config
 
-from airflow.compat.functools import cached_property
 from airflow.exceptions import AirflowException
 from airflow.providers.amazon.aws.hooks.base_aws import AwsBaseHook
 

--- a/airflow/emr_serverless/operators/emr.py
+++ b/airflow/emr_serverless/operators/emr.py
@@ -17,7 +17,7 @@
 # under the License.
 from __future__ import annotations
 
-import sys
+from functools import cached_property
 from typing import TYPE_CHECKING, Dict, Optional, Sequence
 from uuid import uuid4
 
@@ -29,14 +29,7 @@ from airflow.models import BaseOperator
 if TYPE_CHECKING:
     from airflow.utils.context import Context
 
-from airflow.compat.functools import cached_property
-
 DEFAULT_CONN_ID = "aws_default"
-
-if sys.version_info >= (3, 8):
-    from functools import cached_property
-else:
-    from cached_property import cached_property
 
 
 class EmrServerlessCreateApplicationOperator(BaseOperator):

--- a/airflow/requirements-dev.txt
+++ b/airflow/requirements-dev.txt
@@ -1,4 +1,4 @@
-apache-airflow~=2.2.2
-apache-airflow-providers-amazon~=4.0
-pytest~=7.1.2
+apache-airflow~=2.11.0
+apache-airflow-providers-amazon~=9.22
+pytest~=9.0
 boto3>=1.23.9,~=1.23


### PR DESCRIPTION
## Summary

Bumps the standalone Airflow example (`airflow/`) from Airflow 2.2 → 2.11.x. This is the largest single Dependabot fix, clearing **24 of the remaining 37 alerts**.

## Changes

### `airflow/requirements-dev.txt`
```
apache-airflow                  ~=2.2.2  ->  ~=2.11.0
apache-airflow-providers-amazon ~=4.0    ->  ~=9.22
pytest                          ~=7.1.2  ->  ~=9.0
```

### Custom operator/hook import fixes
`airflow.compat.functools` was removed in Airflow 2.4. The two imports of `cached_property` from that path are replaced with `from functools import cached_property` (stdlib, available since Python 3.8). A dead `sys.version_info >= (3, 8)` fallback in `operators/emr.py` is removed — Airflow 2.11 requires Python 3.9+.

## Alerts cleared (24)

#47 #48 #49 #52 #53 #55 #56 #57 #58 #59 #60 #61 #62 #63 #64 #65 #68 #75 #76 #77 #78 #79 #81 #86

## Alerts NOT cleared by this PR

- #87 #88 #89 — require Apache Airflow 3.2.0. 3.x is a major-version bump with breaking changes to custom-operator APIs; out of scope here and tracked separately.
- #80 (providers-amazon in the MWAA CDK example) — fixed in a separate PR alongside bumping the MWAA environment's `airflow_version`.
- Phase 4 alerts in `examples/pyspark/delta-lake/poetry.lock` — tracked separately.

## Verification

Installed `apache-airflow==2.11.0` + `apache-airflow-providers-amazon>=9.22` + `pytest==9.0.3` under Python 3.11:

- All custom hooks/operators/sensors import without error
- `pytest tests/test_dag_integrity.py` ✅ passes
- `tests/test_simple_submit.py` has pre-existing failures (uses removed `DAG.run(executor=...)` signature and deprecated `schedule_interval`). These are integration tests against a live EMR-S application and were not running cleanly prior to this change — out of scope.

## Related

- #61 merged earlier (Postgres JDBC)
- #76 merged earlier (CDK pytest)
- Follow-up PRs: MWAA Airflow 2.11 bump, delta-lake poetry regeneration