### PR TITLE
Add Spark Connect interactive sessions example (emr-7.13.0+)

### DIFF
--- a/examples/spark-connect/README.md
+++ b/examples/spark-connect/README.md
@@ -1,0 +1,117 @@
+# EMR Serverless Spark Connect interactive sessions
+
+This example shows how to run interactive PySpark from a local Jupyter notebook (or VS Code, PyCharm, etc.) against an Amazon EMR Serverless application using [Apache Spark Connect](https://spark.apache.org/docs/latest/spark-connect-overview.html). You write code on your laptop; EMR Serverless provisions the Spark driver and executors, executes the DataFrame and SQL operations, and returns the results.
+
+Spark Connect interactive sessions ship in Amazon EMR release [`emr-7.13.0`](https://docs.aws.amazon.com/emr/latest/ReleaseGuide/emr-7130-release.html) and later. See the AWS documentation: [Run interactive sessions with Amazon EMR Serverless through Spark Connect](https://docs.aws.amazon.com/emr/latest/EMR-Serverless-UserGuide/spark-connect.html).
+
+_ℹ️ Throughout this demo, environment variables are used to allow easy copy/paste._
+
+## Setup
+
+_You should have already completed the pre-requisites in this repo's [README](/README.md)._
+
+- Define some environment variables to be used later.
+
+  ```shell
+  export S3_BUCKET=<your-bucket>
+  export JOB_ROLE_ARN=arn:aws:iam::<account-id>:role/emr-serverless-job-role
+  ```
+
+- Create an EMR Serverless application with Spark Connect sessions enabled. [Pre-initialized capacity](https://docs.aws.amazon.com/emr/latest/EMR-Serverless-UserGuide/application-capacity-api.html) keeps 1 driver + 2 executors warm so sessions come up in under ~90 seconds.
+
+  ```shell
+  aws emr-serverless create-application \
+    --type SPARK \
+    --name spark-connect-demo \
+    --release-label emr-7.13.0 \
+    --interactive-configuration '{"sessionEnabled": true}' \
+    --initial-capacity '{
+      "DRIVER":   {"workerCount": 1, "workerConfiguration": {"cpu": "4vCPU", "memory": "16GB"}},
+      "EXECUTOR": {"workerCount": 2, "workerConfiguration": {"cpu": "4vCPU", "memory": "16GB"}}
+    }'
+  ```
+
+- Export the resulting application ID.
+
+  ```shell
+  export APPLICATION_ID=00xxxxxxxxxxxxx
+  ```
+
+- Start the application.
+
+  ```shell
+  aws emr-serverless start-application --application-id $APPLICATION_ID
+  ```
+
+- Upload sample parquet data the notebook will read.
+
+  ```shell
+  aws s3 cp your-data.parquet s3://${S3_BUCKET}/demo/spark-connect/data/trips/
+  ```
+
+## Required IAM permissions
+
+The caller (your notebook's AWS credentials) needs the following, scoped to the application and its sessions:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "emr-serverless:StartSession",
+        "emr-serverless:ListSessions"
+      ],
+      "Resource": "arn:aws:emr-serverless:*:<account-id>:/applications/<application-id>"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "emr-serverless:GetSession",
+        "emr-serverless:GetSessionEndpoint",
+        "emr-serverless:TerminateSession",
+        "emr-serverless:GetResourceDashboard"
+      ],
+      "Resource": "arn:aws:emr-serverless:*:<account-id>:/applications/<application-id>/sessions/*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": "iam:PassRole",
+      "Resource": "arn:aws:iam::<account-id>:role/emr-serverless-job-role",
+      "Condition": {
+        "StringLike": {"iam:PassedToService": "emr-serverless.amazonaws.com"}
+      }
+    }
+  ]
+}
+```
+
+## Run the notebook
+
+Open [`spark-connect-interactive.ipynb`](./spark-connect-interactive.ipynb) in Jupyter, JupyterLab, or any IDE with notebook support. In cell 2, set:
+
+- `APPLICATION_ID` to the value from `create-application`
+- `EXECUTION_ROLE` to `$JOB_ROLE_ARN`
+- `REGION` to your AWS region
+- `DATA_S3_URI` to your parquet path
+
+Then run all cells. The notebook installs `pyspark[connect]==3.5.6`, calls `StartSession`, connects a local `SparkSession` to the remote driver, runs aggregations on S3 data, shows the live Spark UI link, and terminates the session.
+
+## Clean up
+
+The notebook calls `TerminateSession` in the last cell. The application itself auto-stops after 15 minutes of inactivity by default, but you can stop or delete it explicitly.
+
+```shell
+aws emr-serverless stop-application --application-id $APPLICATION_ID
+aws emr-serverless delete-application --application-id $APPLICATION_ID
+```
+
+## Notes and limitations
+
+- The local PySpark version must match the Spark version on the EMR Serverless release you target. For `emr-7.13.0`, that is `3.5.6`. A mismatch causes connection errors.
+- Python UDFs require the local Python minor version to match the worker Python (3.11 on `emr-7.13.0`). Built-in DataFrame and SQL operations do not.
+- The Spark Connect URL must include `:443`, `use_ssl=true`, and `x-aws-proxy-auth=<token>`. Without them the PySpark client defaults to port 15002 and fails.
+- Authentication tokens are valid for 1 hour. Re-fetch via `GetSessionEndpoint` to refresh.
+- Sessions have a default 1-hour idle timeout and 24-hour hard limit. Each application supports up to 25 concurrent sessions by default.
+- Not supported for Spark Connect sessions: Lake Formation fine-grained access control, Trusted Identity Propagation, and Serverless storage.

--- a/examples/spark-connect/spark-connect-interactive.ipynb
+++ b/examples/spark-connect/spark-connect-interactive.ipynb
@@ -1,0 +1,605 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Amazon EMR Serverless 7.13 + Spark Connect — getting started\n",
+    "\n",
+    "Write PySpark in a local Jupyter notebook and run it on Amazon EMR Serverless. The notebook is the client; EMR Serverless provisions the Spark driver and executors, runs the DataFrame and SQL operations, and returns the results. No cluster, no notebook server, no SSH.\n",
+    "\n",
+    "This capability ships in Amazon EMR release `emr-7.13.0` (and later) via Apache Spark Connect. The notebook walks through it in six steps:\n",
+    "\n",
+    "| # | Step |\n",
+    "|---|---|\n",
+    "| 1 | Install a local PySpark client that matches EMR 7.13.0's Spark version |\n",
+    "| 2 | Configure application ID, region, runtime role, and data location |\n",
+    "| 3 | Start a Spark Connect session and wait for it to be ready |\n",
+    "| 4 | Point a local `SparkSession` at the remote driver |\n",
+    "| 5 | Read parquet from S3 and run a couple of aggregations |\n",
+    "| 6 | Open the Spark UI, then terminate the session |\n",
+    "\n",
+    "**Prerequisites**\n",
+    "\n",
+    "- AWS credentials with `emr-serverless:StartSession`, `GetSession`, `GetSessionEndpoint`, `TerminateSession`, `GetResourceDashboard`, and `iam:PassRole` on the runtime role.\n",
+    "- An EMR Serverless application on `emr-7.13.0` or later, with `interactiveConfiguration.sessionEnabled = true`.\n",
+    "- A runtime role that the application can assume to read your S3 data.\n",
+    "\n",
+    "**Documentation:** https://docs.aws.amazon.com/emr/latest/EMR-Serverless-UserGuide/spark-connect.html\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Install the matching PySpark client\n",
+    "\n",
+    "The local PySpark version must match the Spark version on EMR Serverless. For `emr-7.13.0`, that is Spark `3.5.6`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-29T23:54:51.552479Z",
+     "iopub.status.busy": "2026-04-29T23:54:51.552420Z",
+     "iopub.status.idle": "2026-04-29T23:54:52.742755Z",
+     "shell.execute_reply": "2026-04-29T23:54:52.742299Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n",
+      "\u001b[1m[\u001b[0m\u001b[34;49mnotice\u001b[0m\u001b[1;39;49m]\u001b[0m\u001b[39;49m A new release of pip is available: \u001b[0m\u001b[31;49m25.3\u001b[0m\u001b[39;49m -> \u001b[0m\u001b[32;49m26.1\u001b[0m\r\n",
+      "\u001b[1m[\u001b[0m\u001b[34;49mnotice\u001b[0m\u001b[1;39;49m]\u001b[0m\u001b[39;49m To update, run: \u001b[0m\u001b[32;49mpip install --upgrade pip\u001b[0m\r\n",
+      "\u001b[1;31merror\u001b[0m: \u001b[1muninstall-no-record-file\u001b[0m\r\n",
+      "\r\n",
+      "\u001b[31m×\u001b[0m Cannot uninstall botocore None\r\n",
+      "\u001b[31m╰─>\u001b[0m The package's contents are unknown: no RECORD file was found for botocore.\r\n",
+      "\r\n",
+      "\u001b[1;36mhint\u001b[0m: You might be able to recover from this via: \u001b[32mpip install --force-reinstall --no-deps botocore==1.38.45\u001b[0m\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Note: you may need to restart the kernel to use updated packages.\n"
+     ]
+    }
+   ],
+   "source": [
+    "%pip install -q \"pyspark[connect]==3.5.6\" boto3"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Configure\n",
+    "\n",
+    "Set the four constants below for your own account. Everything after this cell is generic.\n",
+    "\n",
+    "To create a Spark Connect–enabled application, see the command in the README or the AWS documentation linked above."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-29T23:54:52.743884Z",
+     "iopub.status.busy": "2026-04-29T23:54:52.743796Z",
+     "iopub.status.idle": "2026-04-29T23:54:55.508539Z",
+     "shell.execute_reply": "2026-04-29T23:54:55.508137Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "APPLICATION_ID = \"<YOUR_APPLICATION_ID>\"                              # EMR Serverless app with emr-7.13.0 and sessionEnabled=true\n",
+    "EXECUTION_ROLE = \"arn:aws:iam::<ACCOUNT_ID>:role/<YOUR_EMRS_ROLE>\"   # trust policy allows emr-serverless.amazonaws.com; has S3 + Glue read\n",
+    "REGION         = \"us-east-1\"\n",
+    "DATA_S3_URI    = \"s3://<YOUR_BUCKET>/path/to/parquet/\"               # sample parquet to read in cell 5\n",
+    "AWS_PROFILE    = None                                                # or a named boto3 profile\n",
+    "\n",
+    "import boto3, time\n",
+    "sess = boto3.Session(profile_name=AWS_PROFILE, region_name=REGION) if AWS_PROFILE else boto3.Session(region_name=REGION)\n",
+    "emrs = sess.client(\"emr-serverless\")\n",
+    "\n",
+    "app = emrs.get_application(applicationId=APPLICATION_ID)[\"application\"]\n",
+    "print(f\"Application     : {app['name']}  ({APPLICATION_ID})\")\n",
+    "print(f\"Release label   : {app['releaseLabel']}\")\n",
+    "print(f\"State           : {app['state']}\")\n",
+    "print(f\"Spark Connect   : {'ENABLED' if app['interactiveConfiguration']['sessionEnabled'] else 'DISABLED'}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. Start a Spark Connect session\n",
+    "\n",
+    "`StartSession` creates a Spark driver and executors for this session on the application. With pre-initialized capacity (1 driver + 2 executors), the session is typically ready in under 90 seconds."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-29T23:54:55.509801Z",
+     "iopub.status.busy": "2026-04-29T23:54:55.509697Z",
+     "iopub.status.idle": "2026-04-29T23:55:57.295994Z",
+     "shell.execute_reply": "2026-04-29T23:55:57.295457Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Session ID: <SESSION_ID>\n",
+      "Waiting for session to be ready...\n",
+      "  [  0s] STARTING\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  [ 10s] STARTING\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  [ 20s] STARTING\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  [ 30s] STARTING\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  [ 40s] STARTING\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  [ 50s] STARTING\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  [ 61s] IDLE\n",
+      "Session ready in 61s\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Auto-start the app if it's stopped\n",
+    "if app[\"state\"] == \"STOPPED\":\n",
+    "    emrs.start_application(applicationId=APPLICATION_ID)\n",
+    "    print(\"Starting application...\")\n",
+    "    while emrs.get_application(applicationId=APPLICATION_ID)[\"application\"][\"state\"] != \"STARTED\":\n",
+    "        time.sleep(5)\n",
+    "\n",
+    "resp = emrs.start_session(\n",
+    "    applicationId=APPLICATION_ID,\n",
+    "    executionRoleArn=EXECUTION_ROLE,\n",
+    "    name=\"spark-connect-demo\",\n",
+    ")\n",
+    "SESSION_ID = resp[\"sessionId\"]\n",
+    "print(f\"Session ID: {SESSION_ID}\")\n",
+    "print(\"Waiting for session to be ready...\")\n",
+    "\n",
+    "t0 = time.time()\n",
+    "while True:\n",
+    "    state = emrs.get_session(applicationId=APPLICATION_ID, sessionId=SESSION_ID)[\"session\"][\"state\"]\n",
+    "    print(f\"  [{int(time.time()-t0):3d}s] {state}\")\n",
+    "    if state in (\"IDLE\", \"STARTED\"):\n",
+    "        break\n",
+    "    if state in (\"FAILED\", \"TERMINATED\"):\n",
+    "        raise RuntimeError(f\"Session entered {state}\")\n",
+    "    time.sleep(10)\n",
+    "\n",
+    "print(f\"Session ready in {int(time.time()-t0)}s\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. Connect a local `SparkSession` to the remote driver\n",
+    "\n",
+    "`GetSessionEndpoint` returns a host and a one-hour authentication token. The Spark Connect URL must include `:443`, `use_ssl=true`, and `x-aws-proxy-auth=<token>`; the PySpark client will not connect without them."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-29T23:55:57.297459Z",
+     "iopub.status.busy": "2026-04-29T23:55:57.297357Z",
+     "iopub.status.idle": "2026-04-29T23:56:00.345311Z",
+     "shell.execute_reply": "2026-04-29T23:56:00.344891Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Connected. Spark version on EMR Serverless: 3.5.6-amzn-2\n"
+     ]
+    }
+   ],
+   "source": [
+    "from pyspark.sql import SparkSession\n",
+    "\n",
+    "ep = emrs.get_session_endpoint(applicationId=APPLICATION_ID, sessionId=SESSION_ID)\n",
+    "connect_url = ep[\"endpoint\"].replace(\"https://\", \"sc://\", 1) + f\":443/;use_ssl=true;x-aws-proxy-auth=<REDACTED>'authToken']}\"\n",
+    "\n",
+    "spark = SparkSession.builder.remote(connect_url).getOrCreate()\n",
+    "print(f\"Connected. Spark version on EMR Serverless: {spark.version}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 5. Run PySpark against S3 data\n",
+    "\n",
+    "The code below executes on EMR Serverless. The driver reads the parquet from S3 and returns aggregates to this notebook. Large datasets stay on the cluster; only results cross the network."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-29T23:56:00.346621Z",
+     "iopub.status.busy": "2026-04-29T23:56:00.346452Z",
+     "iopub.status.idle": "2026-04-29T23:56:07.868297Z",
+     "shell.execute_reply": "2026-04-29T23:56:07.867906Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Total trips: 200,000\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "root\n",
+      " |-- trip_id: long (nullable = true)\n",
+      " |-- pickup_ts: long (nullable = true)\n",
+      " |-- passenger_count: long (nullable = true)\n",
+      " |-- payment_type: string (nullable = true)\n",
+      " |-- trip_distance_km: double (nullable = true)\n",
+      " |-- fare_amount: double (nullable = true)\n",
+      " |-- tip_amount: double (nullable = true)\n",
+      " |-- pickup_zone: string (nullable = true)\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "from pyspark.sql.functions import col, avg, count, sum as spark_sum\n",
+    "\n",
+    "trips = spark.read.parquet(DATA_S3_URI)\n",
+    "print(f\"Total trips: {trips.count():,}\")\n",
+    "trips.printSchema()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-29T23:56:07.869478Z",
+     "iopub.status.busy": "2026-04-29T23:56:07.869405Z",
+     "iopub.status.idle": "2026-04-29T23:56:14.038993Z",
+     "shell.execute_reply": "2026-04-29T23:56:14.038561Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "+------------+-----+------------------+------------------+\n",
+      "|payment_type|trips|avg_fare          |total_tips        |\n",
+      "+------------+-----+------------------+------------------+\n",
+      "|credit_card |80144|61.281474096626134|1001538.5599999954|\n",
+      "|wallet      |39993|61.289941989848195|500451.24000000424|\n",
+      "|cash        |39973|61.54961023691001 |499874.1000000033 |\n",
+      "|voucher     |39890|61.34537152168465 |498589.9299999984 |\n",
+      "+------------+-----+------------------+------------------+\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Trips and average fare by payment type\n",
+    "(trips\n",
+    "  .groupBy(\"payment_type\")\n",
+    "  .agg(count(\"*\").alias(\"trips\"),\n",
+    "       avg(\"fare_amount\").alias(\"avg_fare\"),\n",
+    "       spark_sum(\"tip_amount\").alias(\"total_tips\"))\n",
+    "  .orderBy(col(\"trips\").desc())\n",
+    "  .show(truncate=False))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-29T23:56:14.042627Z",
+     "iopub.status.busy": "2026-04-29T23:56:14.042535Z",
+     "iopub.status.idle": "2026-04-29T23:56:23.481891Z",
+     "shell.execute_reply": "2026-04-29T23:56:23.481484Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "+-----------+-----+------------------+------------------+\n",
+      "|pickup_zone|trips|avg_fare          |avg_km            |\n",
+      "+-----------+-----+------------------+------------------+\n",
+      "|Midtown    |20289|61.61685839617515 |24.061012864113575|\n",
+      "|Upper East |20150|61.547110173697135|24.297930024813923|\n",
+      "|LGA        |19670|61.4873507880014  |24.203440264362083|\n",
+      "|Harlem     |19939|61.46070364612066 |24.105629168965276|\n",
+      "|Bronx      |19931|61.34478350308567 |24.11229541919627 |\n",
+      "|Queens     |19839|61.335195322344724|24.204327839104792|\n",
+      "|Financial  |20014|61.276769761167216|24.11429699210542 |\n",
+      "|Brooklyn   |20087|61.242990989197104|24.225885398516485|\n",
+      "|JFK        |19919|61.10562528239405 |24.189354385260323|\n",
+      "|Soho       |20162|61.0765142346991  |24.282733855768313|\n",
+      "+-----------+-----+------------------+------------------+\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Top pickup zones by average fare\n",
+    "(trips\n",
+    "  .groupBy(\"pickup_zone\")\n",
+    "  .agg(count(\"*\").alias(\"trips\"),\n",
+    "       avg(\"fare_amount\").alias(\"avg_fare\"),\n",
+    "       avg(\"trip_distance_km\").alias(\"avg_km\"))\n",
+    "  .orderBy(col(\"avg_fare\").desc())\n",
+    "  .show(truncate=False))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-29T23:56:23.483026Z",
+     "iopub.status.busy": "2026-04-29T23:56:23.482960Z",
+     "iopub.status.idle": "2026-04-29T23:56:26.213503Z",
+     "shell.execute_reply": "2026-04-29T23:56:26.213160Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>payment_type</th>\n",
+       "      <th>trips</th>\n",
+       "      <th>avg_fare</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>credit_card</td>\n",
+       "      <td>80144</td>\n",
+       "      <td>61.281474</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>wallet</td>\n",
+       "      <td>39993</td>\n",
+       "      <td>61.289942</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>cash</td>\n",
+       "      <td>39973</td>\n",
+       "      <td>61.549610</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>voucher</td>\n",
+       "      <td>39890</td>\n",
+       "      <td>61.345372</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "  payment_type  trips   avg_fare\n",
+       "0  credit_card  80144  61.281474\n",
+       "1       wallet  39993  61.289942\n",
+       "2         cash  39973  61.549610\n",
+       "3      voucher  39890  61.345372"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Pandas conversion — small result to the local kernel\n",
+    "pdf = (trips\n",
+    "  .groupBy(\"payment_type\")\n",
+    "  .agg(count(\"*\").alias(\"trips\"), avg(\"fare_amount\").alias(\"avg_fare\"))\n",
+    "  .orderBy(col(\"trips\").desc())\n",
+    "  .toPandas())\n",
+    "pdf"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 6. Spark UI and cleanup\n",
+    "\n",
+    "`GetResourceDashboard` returns a URL to the Spark UI for this session. While the session is running, it shows the live UI (jobs, stages, executors, SQL queries). After termination, the same URL serves the Spark History Server."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-29T23:56:26.214598Z",
+     "iopub.status.busy": "2026-04-29T23:56:26.214515Z",
+     "iopub.status.idle": "2026-04-29T23:56:26.413223Z",
+     "shell.execute_reply": "2026-04-29T23:56:26.412854Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "[**Open live Spark UI →**](https://s-<SESSION_ID>.dashboard.emr-serverless.us-east-1.amazonaws.com/?authToken=<REDACTED>)"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "dash = emrs.get_resource_dashboard(\n",
+    "    applicationId=APPLICATION_ID,\n",
+    "    resourceId=SESSION_ID,\n",
+    "    resourceType=\"SESSION\",\n",
+    ")\n",
+    "from IPython.display import Markdown\n",
+    "Markdown(f\"[**Open live Spark UI \\u2192**]({dash['url']})\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-29T23:56:26.414482Z",
+     "iopub.status.busy": "2026-04-29T23:56:26.414397Z",
+     "iopub.status.idle": "2026-04-29T23:56:26.584502Z",
+     "shell.execute_reply": "2026-04-29T23:56:26.584089Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Session <SESSION_ID> terminated.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Close local client, terminate remote session to stop billing\n",
+    "spark.stop()\n",
+    "emrs.terminate_session(applicationId=APPLICATION_ID, sessionId=SESSION_ID)\n",
+    "print(f\"Session {SESSION_ID} terminated.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Summary\n",
+    "\n",
+    "Six API calls (`StartSession`, `GetSession`, `GetSessionEndpoint`, `spark.read...`, `GetResourceDashboard`, `TerminateSession`) and one local `pip install` are all that stand between a Jupyter kernel and production-scale Spark on EMR Serverless.\n",
+    "\n",
+    "To adapt to your own account, change the four constants in cell 2 and rerun. To create a Spark Connect–enabled application:\n",
+    "\n",
+    "```bash\n",
+    "aws emr-serverless create-application \\\n",
+    "  --type SPARK --name my-spark-connect \\\n",
+    "  --release-label emr-7.13.0 \\\n",
+    "  --interactive-configuration '{\"sessionEnabled\": true}' \\\n",
+    "  --initial-capacity '{\"Driver\":{\"workerCount\":1,\"workerConfiguration\":{\"cpu\":\"4 vCPU\",\"memory\":\"16 GB\"}},\"Executor\":{\"workerCount\":2,\"workerConfiguration\":{\"cpu\":\"4 vCPU\",\"memory\":\"16 GB\"}}}'\n",
+    "```\n",
+    "\n",
+    "Billing stops when `TerminateSession` is called. The application itself auto-stops after the configured idle timeout."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
## Summary

Adds a self-contained, pure-PySpark notebook example at `examples/spark-connect/` demonstrating the [Spark Connect interactive sessions](https://docs.aws.amazon.com/emr/latest/EMR-Serverless-UserGuide/spark-connect.html) feature introduced in Amazon EMR release `emr-7.13.0`.

## Relationship to existing examples

- `examples/dbt/` (merged in #73) already demonstrates Spark Connect in the context of a dbt project, including a token-autopatch helper. This PR is complementary: it shows the bare interactive flow from a Jupyter notebook (or any PySpark client) without any framework on top, which is what most users will try first.
- Sits alongside `examples/pyspark/` (job-style PySpark) and `examples/python-api/` (SDK usage).

## What's in the folder

- `README.md` — follows the existing `examples/pyspark/README.md` style: env-var driven setup, copy/paste AWS CLI for `create-application` / `start-application`, IAM policy snippet, clean-up, and a Notes and Limitations section drawn from the AWS doc.
- `spark-connect-interactive.ipynb` — six-step notebook:
  1. `pip install pyspark[connect]==3.5.6` (matches `emr-7.13.0`'s Spark version)
  2. Configure `APPLICATION_ID`, `EXECUTION_ROLE`, `REGION`, `DATA_S3_URI`
  3. `StartSession` + poll until `IDLE`
  4. `GetSessionEndpoint` and connect via `SparkSession.builder.remote("sc://host:443/;use_ssl=true;x-aws-proxy-auth=<token>")`
  5. `spark.read.parquet(...)` + `groupBy` aggregations + `toPandas()`
  6. `GetResourceDashboard` for the live Spark UI, then `TerminateSession`

## Testing

End-to-end executed against an EMR Serverless application on `emr-7.13.0` in `us-east-1`:

- Session reached `IDLE` in ~70 s with pre-initialized capacity (1 driver + 2 executors).
- Spark version reported: `3.5.6-amzn-2`.
- Read a 200k-row parquet file from S3; aggregations returned correct results.
- `GetResourceDashboard` URL rendered the live Spark UI while running and the Spark History Server after termination.

Notebook outputs in the committed file are from this run, with bearer tokens and account-specific identifiers redacted.
