### PR TITLE
Enhance prerequisites in SparkConnect notebook

### DIFF
--- a/examples/spark-connect/spark-connect-interactive.ipynb
+++ b/examples/spark-connect/spark-connect-interactive.ipynb
@@ -23,6 +23,7 @@
     "\n",
     "- AWS credentials with `emr-serverless:StartSession`, `GetSession`, `GetSessionEndpoint`, `TerminateSession`, `GetResourceDashboard`, and `iam:PassRole` on the runtime role.\n",
     "- An EMR Serverless application on `emr-7.13.0` or later, with `interactiveConfiguration.sessionEnabled = true`.\n",
+    "- `boto3 >= 1.43.0` (to get the latest EMR Serverless session APIs)\n",
     "- A runtime role that the application can assume to read your S3 data.\n",
     "\n",
     "**Documentation:** https://docs.aws.amazon.com/emr/latest/EMR-Serverless-UserGuide/spark-connect.html\n"
@@ -73,7 +74,7 @@
     }
    ],
    "source": [
-    "%pip install -q \"pyspark[connect]==3.5.6\" boto3"
+    "%pip install -q --upgrade setuptools \"boto3>=1.43.0\" \"pyspark[connect]==3.5.6\""
    ]
   },
   {
@@ -107,6 +108,8 @@
     "AWS_PROFILE    = None                                                # or a named boto3 profile\n",
     "\n",
     "import boto3, time\n",
+    "# ensure boto3 version >=1.43.0\n",
+    "print(f\"boto3 version   : {boto3.__version__}\")\n",
     "sess = boto3.Session(profile_name=AWS_PROFILE, region_name=REGION) if AWS_PROFILE else boto3.Session(region_name=REGION)\n",
     "emrs = sess.client(\"emr-serverless\")\n",
     "\n",
@@ -254,7 +257,8 @@
     "from pyspark.sql import SparkSession\n",
     "\n",
     "ep = emrs.get_session_endpoint(applicationId=APPLICATION_ID, sessionId=SESSION_ID)\n",
-    "connect_url = ep[\"endpoint\"].replace(\"https://\", \"sc://\", 1) + f\":443/;use_ssl=true;x-aws-proxy-auth=<REDACTED>'authToken']}\"\n",
+    "connect_url = ep[\"endpoint\"].replace(\"https://\", \"sc://\", 1) + f\":443/;use_ssl=true;x-aws-proxy-auth=\" + ep[\"authToken\"]\n",
+    "print (connect_url)\n",
     "\n",
     "spark = SparkSession.builder.remote(connect_url).getOrCreate()\n",
     "print(f\"Connected. Spark version on EMR Serverless: {spark.version}\")"


### PR DESCRIPTION
Updated prerequisites and installation instructions for boto3 in the Spark Connect interactive notebook.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
